### PR TITLE
fix(docs): correct multiple typos in API reference

### DIFF
--- a/aster-finance-api.md
+++ b/aster-finance-api.md
@@ -243,7 +243,7 @@ It is recommended to use a small recvWindow of 5000 or less!
 </aside>
 
 ### SIGNED Endpoint Examples for POST /fapi/v1/order
-Here is a step-by-step example of how to send a vaild signed payload from the
+Here is a step-by-step example of how to send a valid signed payload from the
 Linux command line using `echo`, `openssl`, and `curl`.
 
 Key | Value
@@ -1817,7 +1817,7 @@ m -> minutes; h -> hours; d -> days; w -> weeks; M -> months
 }
 ```
 
-24hr rollwing window ticker statistics for a single symbol. These are NOT the statistics of the UTC day, but a 24hr rolling window from requestTime to 24hrs before.
+24hr rolling window ticker statistics for a single symbol. These are NOT the statistics of the UTC day, but a 24hr rolling window from requestTime to 24hrs before.
 
 **Stream Name:**     
 ``<symbol>@ticker``
@@ -1856,7 +1856,7 @@ m -> minutes; h -> hours; d -> days; w -> weeks; M -> months
 ]
 ```
 
-24hr rollwing window ticker statistics for all symbols. These are NOT the statistics of the UTC day, but a 24hr rolling window from requestTime to 24hrs before. Note that only tickers that have changed will be present in the array.
+24hr rolling window ticker statistics for all symbols. These are NOT the statistics of the UTC day, but a 24hr rolling window from requestTime to 24hrs before. Note that only tickers that have changed will be present in the array.
 
 **Stream Name:**     
 ``!ticker@arr``
@@ -3325,7 +3325,7 @@ timestamp|LONG|YES|
 
 * If neither `startTime` nor `endTime` is sent, the recent 7-day data will be returned.
 * If `incomeType ` is not sent, all kinds of flow will be returned
-* "trandId" is unique in the same incomeType for a user
+* "tranId" is unique in the same incomeType for a user
 
 
 ## Notional and Leverage Brackets (USER_DATA)
@@ -3412,8 +3412,8 @@ timestamp|LONG|YES|
  			{
  				// for positions of the symbol are in One-way Mode or isolated margined in Hedge Mode
  				"LONG": 1, 	// adl quantile for "LONG" position in hedge mode
- 				"SHORT": 2, 	// adl qauntile for "SHORT" position in hedge mode
- 				"BOTH": 0		// adl qunatile for position in one-way mode
+ 				"SHORT": 2, 	// adl quantile for "SHORT" position in hedge mode
+ 				"BOTH": 0		// adl quantile for position in one-way mode
  			}
  	}
  ]
@@ -3442,7 +3442,7 @@ timestamp|LONG|YES|
 
 * If the positions of the symbol are crossed margined in Hedge Mode:
 	* "HEDGE" as a sign will be returned instead of "BOTH"; 
-	* A same value caculated on unrealized pnls on long and short sides' positions will be shown for "LONG" and "SHORT" when there are positions in both of long and short sides.
+	* A same value calculated on unrealized pnls on long and short sides' positions will be shown for "LONG" and "SHORT" when there are positions in both of long and short sides.
 
 
 
@@ -3767,7 +3767,7 @@ Event type is `ACCOUNT_UPDATE`.
 * When balance or position get updated, this event will be pushed.
 	* `ACCOUNT_UPDATE` will be pushed only when update happens on user's account, including changes on balances, positions, or margin type.
 	* Unfilled orders or cancelled orders will not make the event `ACCOUNT_UPDATE` pushed, since there's no change on positions.
-	* Only positions of symbols with non-zero isolatd wallet or non-zero position amount will be pushed in the "position" part of the event `ACCOUNT_UPDATE` when any position changes.
+	* Only positions of symbols with non-zero isolated wallet or non-zero position amount will be pushed in the "position" part of the event `ACCOUNT_UPDATE` when any position changes.
 
 * When "FUNDING FEE" changes to the user's balance, the event will be pushed with the brief message:
 	* When "FUNDING FEE" occurs in a **crossed position**, `ACCOUNT_UPDATE` will be pushed with only the balance `B`(including the "FUNDING FEE" asset only), without any position `P` message. 
@@ -3834,8 +3834,8 @@ Event type is `ACCOUNT_UPDATE`.
     "ot":"TRAILING_STOP_MARKET",	// Original Order Type
     "ps":"LONG",						// Position Side
     "cp":false,						// If Close-All, pushed with conditional order
-    "AP":"7476.89",				// Activation Price, only puhed with TRAILING_STOP_MARKET order
-    "cr":"5.0",					// Callback Rate, only puhed with TRAILING_STOP_MARKET order
+    "AP":"7476.89",				// Activation Price, only pushed with TRAILING_STOP_MARKET order
+    "cr":"5.0",					// Callback Rate, only pushed with TRAILING_STOP_MARKET order
     "rp":"0"							// Realized Profit of the trade
   }
   

--- a/aster-finance-api.md
+++ b/aster-finance-api.md
@@ -2889,7 +2889,7 @@ timestamp | LONG | YES
 
 
 
-## Account Information V2 (USER_DATA)
+## Account Information V4 (USER_DATA)
 
 
 > **Response:**
@@ -2897,81 +2897,81 @@ timestamp | LONG | YES
 ```javascript
 
 {
-	"feeTier": 0,  		// account commisssion tier 
- 	"canTrade": true,  	// if can trade
- 	"canDeposit": true,  	// if can transfer in asset
- 	"canWithdraw": true, 	// if can transfer out asset
- 	"updateTime": 0,
- 	"totalInitialMargin": "0.00000000",    // total initial margin required with current mark price (useless with isolated positions), only for USDT asset
- 	"totalMaintMargin": "0.00000000",  	  // total maintenance margin required, only for USDT asset
- 	"totalWalletBalance": "23.72469206",     // total wallet balance, only for USDT asset
- 	"totalUnrealizedProfit": "0.00000000",   // total unrealized profit, only for USDT asset
- 	"totalMarginBalance": "23.72469206",     // total margin balance, only for USDT asset
- 	"totalPositionInitialMargin": "0.00000000",    // initial margin required for positions with current mark price, only for USDT asset
- 	"totalOpenOrderInitialMargin": "0.00000000",   // initial margin required for open orders with current mark price, only for USDT asset
- 	"totalCrossWalletBalance": "23.72469206",      // crossed wallet balance, only for USDT asset
- 	"totalCrossUnPnl": "0.00000000",	  // unrealized profit of crossed positions, only for USDT asset
- 	"availableBalance": "23.72469206",       // available balance, only for USDT asset
- 	"maxWithdrawAmount": "23.72469206"     // maximum amount for transfer out, only for USDT asset
- 	"assets": [
- 		{
- 			"asset": "USDT",			// asset name
-		   	"walletBalance": "23.72469206",      // wallet balance
-		   	"unrealizedProfit": "0.00000000",    // unrealized profit
-		   	"marginBalance": "23.72469206",      // margin balance
-		   	"maintMargin": "0.00000000",	    // maintenance margin required
-		   	"initialMargin": "0.00000000",    // total initial margin required with current mark price 
-		   	"positionInitialMargin": "0.00000000",    //initial margin required for positions with current mark price
-		   	"openOrderInitialMargin": "0.00000000",   // initial margin required for open orders with current mark price
-		   	"crossWalletBalance": "23.72469206",      // crossed wallet balance
-		   	"crossUnPnl": "0.00000000"       // unrealized profit of crossed positions
-		   	"availableBalance": "23.72469206",       // available balance
-		   	"maxWithdrawAmount": "23.72469206",     // maximum amount for transfer out
-		   	"marginAvailable": true,    // whether the asset can be used as margin in Multi-Assets mode
-		   	"updateTime": 1625474304765 // last update time 
-		},
-		{
- 			"asset": "BUSD",			// asset name
-		   	"walletBalance": "103.12345678",      // wallet balance
-		   	"unrealizedProfit": "0.00000000",    // unrealized profit
-		   	"marginBalance": "103.12345678",      // margin balance
-		   	"maintMargin": "0.00000000",	    // maintenance margin required
-		   	"initialMargin": "0.00000000",    // total initial margin required with current mark price 
-		   	"positionInitialMargin": "0.00000000",    //initial margin required for positions with current mark price
-		   	"openOrderInitialMargin": "0.00000000",   // initial margin required for open orders with current mark price
-		   	"crossWalletBalance": "103.12345678",      // crossed wallet balance
-		   	"crossUnPnl": "0.00000000"       // unrealized profit of crossed positions
-		   	"availableBalance": "103.12345678",       // available balance
-		   	"maxWithdrawAmount": "103.12345678",     // maximum amount for transfer out
-		   	"marginAvailable": true,    // whether the asset can be used as margin in Multi-Assets mode
-		   	"updateTime": 1625474304765 // last update time
-		}
-	],
- 	"positions": [  // positions of all symbols in the market are returned
- 		// only "BOTH" positions will be returned with One-way mode
- 		// only "LONG" and "SHORT" positions will be returned with Hedge mode
- 		{
-		 	"symbol": "BTCUSDT",  	// symbol name
-		   	"initialMargin": "0",	// initial margin required with current mark price 
-		   	"maintMargin": "0",		// maintenance margin required
-		   	"unrealizedProfit": "0.00000000",  // unrealized profit
-		   	"positionInitialMargin": "0",      // initial margin required for positions with current mark price
-		   	"openOrderInitialMargin": "0",     // initial margin required for open orders with current mark price
-		   	"leverage": "100",		// current initial leverage
-		   	"isolated": true,  		// if the position is isolated
-		   	"entryPrice": "0.00000",  	// average entry price
-		   	"maxNotional": "250000",  	// maximum available notional with current leverage
-		   	"positionSide": "BOTH",  	// position side
-		   	"positionAmt": "0",			// position amount
-		   	"updateTime": 0           // last update time
-		}
-  	]
+   "feeTier": 0, // account commisssion tier
+   "canTrade": true, // if can trade
+   "canDeposit": true, // if can transfer in asset
+   "canWithdraw": true, // if can transfer out asset
+   "updateTime": 0,
+   "totalInitialMargin": "0.00000000", // total initial margin required with current mark price (useless with isolated positions), only for USDT asset
+   "totalMaintMargin": "0.00000000", // total maintenance margin required, only for USDT asset
+   "totalWalletBalance": "23.72469206", // total wallet balance, using BidRate/AskRate for value caculation under multi-asset mode
+   "totalUnrealizedProfit": "0.00000000", // total unrealized profit in USDT
+   "totalMarginBalance": "23.72469206", // total margin balance, using BidRate/AskRate for value caculation under multi-asset mode
+   "totalPositionInitialMargin": "0.00000000", // initial margin required for positions with current mark price, only for USDT asset
+   "totalOpenOrderInitialMargin": "0.00000000", // initial margin required for open orders with current mark price, only for USDT asset
+   "totalCrossWalletBalance": "23.72469206", // crossed wallet balance, using BidRate/AskRate for value caculation under multi-asset mode
+   "totalCrossUnPnl": "0.00000000", // unrealized profit of crossed positions in USDT
+   "availableBalance": "23.72469206", // available balance, only for USDT asset
+   "maxWithdrawAmount": "23.72469206" // maximum amount for transfer out, using BidRate for value caculation under multi-asset mode
+   "assets": [
+       {
+           "asset": "USDT", // asset name
+           "walletBalance": "23.72469206", // wallet balance
+           "unrealizedProfit": "0.00000000", // unrealized profit
+           "marginBalance": "23.72469206", // margin balance
+           "maintMargin": "0.00000000", // maintenance margin required
+           "initialMargin": "0.00000000", // total initial margin required with current mark price
+           "positionInitialMargin": "0.00000000", //initial margin required for positions with current mark price
+           "openOrderInitialMargin": "0.00000000", // initial margin required for open orders with current mark price
+           "crossWalletBalance": "23.72469206", // crossed wallet balance
+           "crossUnPnl": "0.00000000" // unrealized profit of crossed positions
+           "availableBalance": "23.72469206", // available balance
+           "maxWithdrawAmount": "23.72469206", // maximum amount for transfer out
+           "marginAvailable": true, // whether the asset can be used as margin in Multi-Assets mode
+           "updateTime": 1625474304765 // last update time
+       },
+       {
+           "asset": "BUSD", // asset name
+           "walletBalance": "103.12345678", // wallet balance
+           "unrealizedProfit": "0.00000000", // unrealized profit
+           "marginBalance": "103.12345678", // margin balance
+           "maintMargin": "0.00000000", // maintenance margin required
+           "initialMargin": "0.00000000", // total initial margin required with current mark price
+           "positionInitialMargin": "0.00000000", //initial margin required for positions with current mark price
+           "openOrderInitialMargin": "0.00000000", // initial margin required for open orders with current mark price
+           "crossWalletBalance": "103.12345678", // crossed wallet balance
+           "crossUnPnl": "0.00000000" // unrealized profit of crossed positions
+           "availableBalance": "103.12345678", // available balance
+           "maxWithdrawAmount": "103.12345678", // maximum amount for transfer out
+           "marginAvailable": true, // whether the asset can be used as margin in Multi-Assets mode
+           "updateTime": 1625474304765 // last update time
+       }
+   ],
+   "positions": [ // positions of all symbols in the market are returned
+       // only "BOTH" positions will be returned with One-way mode
+       // only "LONG" and "SHORT" positions will be returned with Hedge mode
+       {
+           "symbol": "BTCUSDT", // symbol name
+           "initialMargin": "0", // initial margin required with current mark price
+           "maintMargin": "0", // maintenance margin required
+           "unrealizedProfit": "0.00000000", // unrealized profit
+           "positionInitialMargin": "0", // initial margin required for positions with current mark price
+           "openOrderInitialMargin": "0", // initial margin required for open orders with current mark price
+           "leverage": "100", // current initial leverage
+           "isolated": true, // if the position is isolated
+           "entryPrice": "0.00000", // average entry price
+           "maxNotional": "250000", // maximum available notional with current leverage
+           "positionSide": "BOTH", // position side
+           "positionAmt": "0", // position amount
+           "updateTime": 0 // last update time
+       }
+   ]
 }
 ```
 
 
 ``
-GET /fapi/v2/account (HMAC SHA256)
+GET /fapi/v4/account (HMAC SHA256)
 ``
 
 Get current account information.

--- a/aster-finance-api_CN.md
+++ b/aster-finance-api_CN.md
@@ -2786,7 +2786,7 @@ timestamp | LONG | YES
 
 
 
-## 账户信息V2 (USER_DATA)
+## 账户信息V4 (USER_DATA)
 
 > **响应:**
 
@@ -2800,15 +2800,15 @@ timestamp | LONG | YES
  	"updateTime": 0,
  	"totalInitialMargin": "0.00000000",  // 但前所需起始保证金总额(存在逐仓请忽略), 仅计算usdt资产
  	"totalMaintMargin": "0.00000000",  // 维持保证金总额, 仅计算usdt资产
- 	"totalWalletBalance": "23.72469206",   // 账户总余额, 仅计算usdt资产
+ 	"totalWalletBalance": "23.72469206",   // 账户总余额, 联保模式下采用BidRate/AskRate来计算余额
  	"totalUnrealizedProfit": "0.00000000",  // 持仓未实现盈亏总额, 仅计算usdt资产
- 	"totalMarginBalance": "23.72469206",  // 保证金总余额, 仅计算usdt资产
+ 	"totalMarginBalance": "23.72469206",  // 保证金总余额, 联保模式下采用BidRate/AskRate来计算余额
  	"totalPositionInitialMargin": "0.00000000",  // 持仓所需起始保证金(基于最新标记价格), 仅计算usdt资产
  	"totalOpenOrderInitialMargin": "0.00000000",  // 当前挂单所需起始保证金(基于最新标记价格), 仅计算usdt资产
- 	"totalCrossWalletBalance": "23.72469206",  // 全仓账户余额, 仅计算usdt资产
+ 	"totalCrossWalletBalance": "23.72469206",  // 全仓账户余额, 联保模式下采用BidRate/AskRate来计算余额
  	"totalCrossUnPnl": "0.00000000",	// 全仓持仓未实现盈亏总额, 仅计算usdt资产
  	"availableBalance": "23.72469206",       // 可用余额, 仅计算usdt资产
- 	"maxWithdrawAmount": "23.72469206"     // 最大可转出余额, 仅计算usdt资产
+ 	"maxWithdrawAmount": "23.72469206"     // 最大可转出余额, 联保模式下采用BidRate来计算余额
  	"assets": [
  		{
  			"asset": "USDT",	 	//资产
@@ -2866,7 +2866,7 @@ timestamp | LONG | YES
 
 
 ``
-GET /fapi/v2/account (HMAC SHA256)
+GET /fapi/v4/account (HMAC SHA256)
 ``
 
 **权重:**


### PR DESCRIPTION

- Fixed typos: "rollwing" → "rolling", "trandId" → "tranId", "quantile", "caculcated" → "calculated", "isolatd" → "isolated", "puhed" → "pushed"
- No functional changes, only documentation spelling corrections

