### PR TITLE
feat: Add Sell and Stop-loss methods to Aster Exchange client

### DIFF
--- a/Aster.cs
+++ b/Aster.cs
@@ -14,7 +14,6 @@ public class OrderResponse
     public JsonElement Data { get; set; }
 }
 
-// C# Method for Aster Exchange Buy Order
 public class AsterExchange
 {
     private string Sign(string apiSecret, string stringToSign)

--- a/AsterBuy.cs
+++ b/AsterBuy.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+public class OrderResponse
+{
+    public bool Success { get; set; }
+    public string Message { get; set; }
+    public JsonElement Data { get; set; }
+}
+
+// C# Method for Aster Exchange Buy Order
+public class AsterExchange
+{
+    private string Sign(string apiSecret, string stringToSign)
+    {
+        using (var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(apiSecret)))
+        {
+            return BitConverter.ToString(hmac.ComputeHash(Encoding.UTF8.GetBytes(stringToSign))).Replace("-", "").ToLower();
+        }
+    }
+
+    private async Task<OrderResponse> PlaceOrderAsync(string apiKey, string apiSecret, string symbol, decimal quantity, decimal price, string side, string type = "LIMIT", decimal? stopPrice = null)
+    {
+        using (var client = new HttpClient())
+        {
+            try
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, "https://api.aster.exchange/v3/trade");
+
+                var timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+                var parameters = new SortedDictionary<string, string>
+                {
+                    { "api_key", apiKey },
+                    { "timestamp", timestamp },
+                    { "symbol", symbol },
+                    { "quantity", quantity.ToString() },
+                    { "price", price.ToString() },
+                    { "side", side },
+                    { "type", type }
+                };
+
+                if (stopPrice.HasValue)
+                {
+                    parameters.Add("stopPrice", stopPrice.Value.ToString());
+                }
+
+                var stringToSign = string.Join("&", parameters.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+                var signature = Sign(apiSecret, stringToSign);
+                parameters.Add("signature", signature);
+
+                request.Content = new FormUrlEncodedContent(parameters);
+
+                var response = await client.SendAsync(request);
+                var responseContent = await response.Content.ReadAsStringAsync();
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return new OrderResponse { Success = false, Message = $"API Error: {response.StatusCode} - {responseContent}" };
+                }
+
+                var parsedResponse = JsonSerializer.Deserialize<JsonElement>(responseContent);
+                return new OrderResponse { Success = true, Message = "Order placed successfully.", Data = parsedResponse };
+            }
+            catch (HttpRequestException ex)
+            {
+                return new OrderResponse { Success = false, Message = $"Request Error: {ex.Message}" };
+            }
+        }
+    }
+
+    public async Task<List<OrderResponse>> PlaceBuyOrder(string apiKey, string apiSecret, string symbol, decimal quantity, decimal price, decimal stopLossPercentage = 1.0m)
+    {
+        var responses = new List<OrderResponse>();
+
+        var buyOrderResponse = await PlaceOrderAsync(apiKey, apiSecret, symbol, quantity, price, "BUY");
+        responses.Add(buyOrderResponse);
+
+        if (buyOrderResponse.Success)
+        {
+            var stopPrice = price * (1 - (stopLossPercentage / 100));
+            var stopLossResponse = await PlaceStopLossOrder(apiKey, apiSecret, symbol, quantity, stopPrice, stopPrice);
+            responses.Add(stopLossResponse);
+        }
+
+        return responses;
+    }
+
+    public async Task<OrderResponse> PlaceSellOrder(string apiKey, string apiSecret, string symbol, decimal quantity, decimal price)
+    {
+        return await PlaceOrderAsync(apiKey, apiSecret, symbol, quantity, price, "SELL");
+    }
+
+    public async Task<OrderResponse> PlaceStopLossOrder(string apiKey, string apiSecret, string symbol, decimal quantity, decimal price, decimal stopPrice)
+    {
+        return await PlaceOrderAsync(apiKey, apiSecret, symbol, quantity, price, "SELL", "STOP_LOSS_LIMIT", stopPrice);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Threading.Tasks;
+
+public class Program
+{
+    public static async Task Main(string[] args)
+    {
+        Console.Write("Enter your API Key: ");
+        string apiKey = Console.ReadLine();
+
+        Console.Write("Enter your API Secret: ");
+        string apiSecret = Console.ReadLine();
+
+        var exchange = new AsterExchange();
+
+        string symbol = "BTCUSDT"; // Default symbol
+
+        Console.WriteLine("\nChoose an action:");
+        Console.WriteLine("1. Place a Buy Order (with 1% Stop-Loss)");
+        Console.WriteLine("2. Place a Sell Order");
+        Console.Write("Enter your choice (1 or 2): ");
+        string choice = Console.ReadLine();
+
+        if (choice == "1")
+        {
+            Console.Write($"Enter quantity for {symbol}: ");
+            decimal buyQuantity = decimal.Parse(Console.ReadLine());
+            Console.Write($"Enter price for {symbol}: ");
+            decimal buyPrice = decimal.Parse(Console.ReadLine());
+
+            Console.WriteLine($"\nPlacing a buy order for {buyQuantity} {symbol} at {buyPrice} with a 1% stop-loss...");
+
+            var buyResponses = await exchange.PlaceBuyOrder(apiKey, apiSecret, symbol, buyQuantity, buyPrice);
+
+            foreach (var response in buyResponses)
+            {
+                if (response.Success)
+                {
+                    Console.WriteLine("Order placed successfully!");
+                    Console.WriteLine($"Response Data: {response.Data}");
+                }
+                else
+                {
+                    Console.WriteLine($"Failed to place order: {response.Message}");
+                }
+            }
+        }
+        else if (choice == "2")
+        {
+            Console.Write($"Enter quantity for {symbol}: ");
+            decimal sellQuantity = decimal.Parse(Console.ReadLine());
+            Console.Write($"Enter price for {symbol}: ");
+            decimal sellPrice = decimal.Parse(Console.ReadLine());
+
+            Console.WriteLine($"\nPlacing a sell order for {sellQuantity} {symbol} at {sellPrice}...");
+
+            var sellResponse = await exchange.PlaceSellOrder(apiKey, apiSecret, symbol, sellQuantity, sellPrice);
+
+            if (sellResponse.Success)
+            {
+                Console.WriteLine("Order placed successfully!");
+                Console.WriteLine($"Response Data: {sellResponse.Data}");
+            }
+            else
+            {
+                Console.WriteLine($"Failed to place order: {sellResponse.Message}");
+            }
+        }
+        else
+        {
+            Console.WriteLine("Invalid choice.");
+        }
+    }
+}


### PR DESCRIPTION
This commit enhances the Aster Exchange C# client with several features:

- Implemented a `PlaceSellOrder` method for placing sell orders.
- Implemented a `PlaceStopLossOrder` method for placing stop-loss orders.
- the `PlaceBuyOrder` method to automatically place a 1% stop-loss order upon a successful buy.
-  (`Program.cs`) : prompt the user for their API key and secret, and to provide a simple interface for choosing between buy and sell orders.
- The default symbol is "BTCUSDT".