### PR TITLE
fix double-slash typo in DELETE /fapi/v3/mmp CN doc

### DIFF
--- a/aster-finance-futures-api-v3_CN.md
+++ b/aster-finance-futures-api-v3_CN.md
@@ -3726,7 +3726,7 @@ true
 ```
 
 ``
-DELETE /fapi/v3//mmp``
+DELETE /fapi/v3/mmp``
 
 **权重:**
 1


### PR DESCRIPTION
fix double-slash typo in DELETE /fapi/v3/mmp CN doc