### PR TITLE
fix: critical bugs in consolidation.js and demo files (#87, #88)

### DIFF
--- a/consolidation.js
+++ b/consolidation.js
@@ -87,7 +87,7 @@ var value = {
 }
 
 async function getUrl(my_dict) {
-    content = ''
+    let content = ''
     for (let key in my_dict) {
         content = content + key + '=' + my_dict[key] + '&'
     }
@@ -105,12 +105,12 @@ async function sign_v1(secretKey, message) {
 }
 
 async function sendRequest(url, method) {
-    headers = {}
-    key = api_key
-    if (use_new_apikey == true) {
+    let headers = {}
+    let key = api_key
+    if (use_new_apikey === true) {
         key = new_address_apikey
     }
-    if (method == 'POST') {
+    if (method === 'POST') {
         headers = {
             'Content-Type': 'application/x-www-form-urlencoded',
             'X-MBX-APIKEY': key,
@@ -134,12 +134,12 @@ async function sendRequest(url, method) {
 }
 
 async function send_v1(path, method, my_dict) {
-    content = await getUrl(my_dict)
-    secret = api_secret
-    if (use_new_apikey == true) {
+    const content = await getUrl(my_dict)
+    let secret = api_secret
+    if (use_new_apikey === true) {
         secret = new_address_apiSecret
     }
-    signature = await sign_v1(secret, content)
+    const signature = await sign_v1(secret, content)
     path = path + '?' + content + '&signature=' + signature
     return await sendRequest(host + path, method)
 }
@@ -156,32 +156,32 @@ async function generateSignature() {
 }
 
 async function send(config, addParams) {
-    path = config['url']
-    method = config['method']
-    my_dict = { ...config['params'], ...addParams }
+    const path = config['url']
+    const method = config['method']
+    const my_dict = { ...config['params'], ...addParams }
     return await send_v1(path, method, my_dict)
 }
 
 async function sign(private_key, message) {
-    wallet = new ethers.Wallet(private_key);
+    const wallet = new ethers.Wallet(private_key);
     const signature = await wallet.signMessage(message);
     return signature
 }
 
 async function main() {
     //循环归集
-    i = 0
+    let i = 0
     for (const config of new_address_config) {
         console.log('开始归集账户:', config.address);
         //获取创建apikey的nonce
         let nonce = await send(spot_get_nonce, {'address': config.address})
 
         //给新地址创建api_key api_secret
-        message = 'You are signing into Astherus ${nonce}'.replace('${nonce}', nonce)
-        userSignature = await sign(config.private_key,message)
+        const message = 'You are signing into Astherus ${nonce}'.replace('${nonce}', nonce)
+        const userSignature = await sign(config.private_key,message)
         
         //创建apikey时的描述信息 注意同一账户的desc不能重复
-        var key_desc = Date.now() +'_' + i
+        const key_desc = Date.now() +'_' + i
         i = i + 1
         let new_api = await send(spot_create_apikey, { 'userSignature': userSignature,'address': config.address,'desc': key_desc })
         new_address_apikey = new_api['apiKey']
@@ -192,10 +192,10 @@ async function main() {
 
         use_new_apikey = true
         //归集 使用新生成的apikey api_secret 将新地址的CDL转账到老地址账户
-        sendToMainAddressRes = await send(spot_send_toAddress, { 'asset': config.asset, "amount": config.amount, "toAddress": main_address })
+        const sendToMainAddressRes = await send(spot_send_toAddress, { 'asset': config.asset, "amount": config.amount, "toAddress": main_address })
         console.log('sendToMainAddressRes:', sendToMainAddressRes)
         use_new_apikey = false
-        if(sendToMainAddressRes['status'] = 'SUCCESS'){
+        if(sendToMainAddressRes && sendToMainAddressRes['status'] === 'SUCCESS'){
             console.log('归集成功:', config.address);
         }else{
             console.log('归集失败:', config.address);
@@ -203,25 +203,25 @@ async function main() {
     }
 
 
-    estimateFee = await send(spot_withdraw_estimateFee, {})
+    const estimateFee = await send(spot_withdraw_estimateFee, {})
     console.log('estimateFee:', estimateFee)
 
 
     //归集和提现的手续费 代币 数量配置
-    fee = estimateFee['gasCost']
+    const fee = estimateFee['gasCost']
     value.fee = fee*1.5+''
     console.log('提现手续费:', value.fee)
 
 
-    withdraw_ignature = await generateSignature()
+    const withdraw_signature = await generateSignature()
 
     //使用老账户进行提现操作
-    spotWithdraw = await send(spot_withdraw, {
+    const spotWithdraw = await send(spot_withdraw, {
         'fee':  value.fee, 'nonce': withdraw_nonce,
-        'userSignature': withdraw_ignature, 'receiver': main_address, 'asset': withdraw_asset, 'amount': withdraw_amount
+        'userSignature': withdraw_signature, 'receiver': main_address, 'asset': withdraw_asset, 'amount': withdraw_amount
     })
 
-    if(spotWithdraw['hash'] != ''){
+    if(spotWithdraw && spotWithdraw['hash'] !== ''){
         console.log('提现成功:', spotWithdraw['hash']);
     }else{
         console.log('提现失败:', spotWithdraw);

--- a/demo/aster-code.py
+++ b/demo/aster-code.py
@@ -13,14 +13,16 @@ chain_id = 1666
 # aster_chain = 'Testnet'
 # chain_id = 714
 
-user = '0x014c85ffb0fF2F2972237AA950B452f92C69Ae1D'
-main_private_key = '*'
+# ⚠️  WARNING: Replace these with your own addresses and keys before use.
+# These are PLACEHOLDER values — do NOT use on mainnet.
+user = '0xYOUR_MAIN_WALLET_ADDRESS'
+main_private_key = '0xYOUR_MAIN_PRIVATE_KEY'
 
 
-signer = '0xC98Fd64eBc39E28b92849d9cCef9495663439014'
-priKey =  '*'
+signer = '0xYOUR_AGENT_WALLET_ADDRESS'
+priKey =  '0xYOUR_AGENT_PRIVATE_KEY'
 
-builder = '0x014c85ffb0fF2F2972237AA950B452f92C69Ae1D'
+builder = '0xYOUR_BUILDER_ADDRESS'
 approveAgent = {'url': '/fapi/v3/approveAgent', 'method': 'POST',
               'params':{'agentName': 'ivanbuilder','agentAddress':signer,
                       'ipWhitelist':'', 'expired':1967945395040,'canSpotTrade':True,

--- a/demo/sol_agent.py
+++ b/demo/sol_agent.py
@@ -8,12 +8,13 @@ from nacl.signing import SigningKey
 import time
 import requests
 
-user = '6mSp4BuWCNgRSwv8JopQwCma26hmBT8jrcgJNadq23Gt'
-base58_private_key = '*'
-signer = '0x71949710270163F096A8Bd342b266183Ae742e5E'
-signer_pri_key =  '*'
+# ⚠️  WARNING: Replace these with your own addresses and keys before use.
+user = 'YOUR_SOLANA_PUBLIC_KEY'
+base58_private_key = 'YOUR_SOLANA_PRIVATE_KEY'
+signer = '0xYOUR_AGENT_WALLET_ADDRESS'
+signer_pri_key =  '0xYOUR_AGENT_PRIVATE_KEY'
 
-builder = '0x014c85ffb0fF2F2972237AA950B452f92C69Ae1D'
+builder = '0xYOUR_BUILDER_ADDRESS'
 host = 'https://fapi3.asterdex.com'
 
 headers = {


### PR DESCRIPTION
## Bug Fixes

### #87 — `consolidation.js`: Assignment instead of comparison (CRITICAL)

**Line 198 (before):**
```js
if(sendToMainAddressRes['status'] = 'SUCCESS'){
```

**Line 198 (after):**
```js
if(sendToMainAddressRes && sendToMainAddressRes['status'] === 'SUCCESS'){
```

**Impact:** The `=` operator assigns `'SUCCESS'` to `status` instead of comparing it. The condition **always evaluates to true**, silently masking failed consolidation transfers. Users copying this demo code would never know their transfers failed.

**Additional fixes in same file:**
- Add null checks on `sendToMainAddressRes` and `spotWithdraw` API responses (prevent `TypeError: Cannot read properties of undefined`)
- Fix typo: `withdraw_ignature` → `withdraw_signature`
- Replace all implicit globals (`content`, `headers`, `key`, `secret`, `signature`, `path`, `method`, `wallet`, `i`, `message`, `userSignature`, `sendToMainAddressRes`, `estimateFee`, `fee`, `spotWithdraw`) with proper `let`/`const` declarations
- Replace all loose `==` with strict `===`

### #88 — `aster-code.py` & `sol_agent.py`: Hardcoded wallet addresses

**Before:** Real developer ETH/SOL addresses hardcoded in demo files:
- `0x014c85ffb0fF2F2972237AA950B452f92C69Ae1D` (ETH)
- `0xC98Fd64eBc39E28b92849d9cCef9495663439014` (ETH)
- `0x71949710270163F096A8Bd342b266183Ae742e5E` (ETH)
- `6mSp4BuWCNgRSwv8JopQwCma26hmBT8jrcgJNadq23Gt` (SOL)

**After:** Replaced with `YOUR_*` placeholder values + warning comments.

**Impact:** Users copying demo code could accidentally send funds/approve agents for the wrong wallet address.

## Files Changed

| File | Changes |
|------|---------|
| `consolidation.js` | 25 lines changed |
| `demo/aster-code.py` | 7 lines changed |
| `demo/sol_agent.py` | 6 lines changed |

## Verification

- Zero hardcoded addresses remaining
- Zero loose `==` operators
- Zero implicit globals
- Typo fixed
- No new dependencies, no breaking changes

---
*Submitted by [Kairos Lab](https://github.com/Valisthea)*