### PR TITLE
docs: remove HMAC SHA256 labels from V3 API endpoint headings

### DIFF
--- a/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
@@ -2036,7 +2036,7 @@ Considering the possible data latency from RESTful endpoints during an extremely
 }
 ```
 
-``POST /fapi/v3/positionSide/dual (HMAC SHA256)``
+``POST /fapi/v3/positionSide/dual``
 
 Change user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 
@@ -2061,7 +2061,7 @@ Change user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 }
 ```
 
-``GET /fapi/v3/positionSide/dual (HMAC SHA256)``
+``GET /fapi/v3/positionSide/dual``
 
 Get user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 
@@ -2086,7 +2086,7 @@ Get user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 }
 ```
 
-``POST /fapi/v3/multiAssetsMargin (HMAC SHA256)``
+``POST /fapi/v3/multiAssetsMargin``
 
 Change user's Multi-Assets mode (Multi-Assets Mode or Single-Asset Mode) on ***Every symbol***
 
@@ -2111,7 +2111,7 @@ Change user's Multi-Assets mode (Multi-Assets Mode or Single-Asset Mode) on ***E
 }
 ```
 
-``GET /fapi/v3/multiAssetsMargin (HMAC SHA256)``
+``GET /fapi/v3/multiAssetsMargin``
 
 Get user's Multi-Assets mode (Multi-Assets Mode or Single-Asset Mode) on ***Every symbol***
 
@@ -2157,7 +2157,7 @@ Get user's Multi-Assets mode (Multi-Assets Mode or Single-Asset Mode) on ***Ever
 }
 ```
 
-``POST /fapi/v3/order  (HMAC SHA256)``
+``POST /fapi/v3/order ``
 
 Send in a new order.
 
@@ -2322,7 +2322,7 @@ price  |  DECIMAL | NO | Order price
 ]
 ```
 
-``POST /fapi/v3/batchOrders  (HMAC SHA256)``
+``POST /fapi/v3/batchOrders ``
 
 **Weight:**
 5
@@ -2372,7 +2372,7 @@ price  |  DECIMAL | NO | Order price
 ```
 
 ``
-POST /fapi/v3/asset/wallet/transfer  (HMAC SHA256)
+POST /fapi/v3/asset/wallet/transfer 
 ``
 
 **Weight:**
@@ -2427,7 +2427,7 @@ Notes:
 }
 ```
 
-``GET /fapi/v3/order (HMAC SHA256)``
+``GET /fapi/v3/order``
 
 Check an order's status.
 
@@ -2484,7 +2484,7 @@ Notes:
 }
 ```
 
-``DELETE /fapi/v3/order  (HMAC SHA256)``
+``DELETE /fapi/v3/order ``
 
 Cancel an active order.
 
@@ -2514,7 +2514,7 @@ Either `orderId` or `origClientOrderId` must be sent.
 }
 ```
 
-``DELETE /fapi/v3/allOpenOrders  (HMAC SHA256)``
+``DELETE /fapi/v3/allOpenOrders ``
 
 **Weight:**
 1
@@ -2564,7 +2564,7 @@ Either `orderId` or `origClientOrderId` must be sent.
 ]
 ```
 
-``DELETE /fapi/v3/batchOrders  (HMAC SHA256)``
+``DELETE /fapi/v3/batchOrders ``
 
 **Weight:**
 1
@@ -2594,7 +2594,7 @@ Either `orderIdList` or `origClientOrderIdList ` must be sent.
 
 Cancel all open orders of the specified symbol at the end of the specified countdown.
 
-``POST /fapi/v3/countdownCancelAll  (HMAC SHA256)``
+``POST /fapi/v3/countdownCancelAll ``
 
 **Weight:**
 10
@@ -2647,7 +2647,7 @@ Cancel all open orders of the specified symbol at the end of the specified count
 }
 ```
 
-``GET /fapi/v3/openOrder  (HMAC SHA256)``
+``GET /fapi/v3/openOrder ``
 
 **Weight:** 1
 
@@ -2698,7 +2698,7 @@ Cancel all open orders of the specified symbol at the end of the specified count
 ]
 ```
 
-``GET /fapi/v3/openOrders  (HMAC SHA256)``
+``GET /fapi/v3/openOrders ``
 
 Get all open orders on a symbol. **Careful** when accessing this with no symbol.
 
@@ -2749,7 +2749,7 @@ Get all open orders on a symbol. **Careful** when accessing this with no symbol.
 ]
 ```
 
-``GET /fapi/v3/allOrders (HMAC SHA256)``
+``GET /fapi/v3/allOrders``
 
 Get all account orders; active, canceled, or filled.
 
@@ -2798,7 +2798,7 @@ Get all account orders; active, canceled, or filled.
 ]
 ```
 
-``GET /fapi/v3/balance (HMAC SHA256)``
+``GET /fapi/v3/balance``
 
 **Weight:**
 5
@@ -2888,7 +2888,7 @@ Get all account orders; active, canceled, or filled.
 }
 ```
 
-``GET /fapi/v3/accountWithJoinMargin (HMAC SHA256)``
+``GET /fapi/v3/accountWithJoinMargin``
 
 Get current account information.
 
@@ -2914,7 +2914,7 @@ Get current account information.
 }
 ```
 
-``POST /fapi/v3/leverage (HMAC SHA256)``
+``POST /fapi/v3/leverage``
 
 Change user's initial leverage of specific symbol market.
 
@@ -2941,7 +2941,7 @@ Change user's initial leverage of specific symbol market.
 }
 ```
 
-``POST /fapi/v3/marginType (HMAC SHA256)``
+``POST /fapi/v3/marginType``
 
 **Weight:**
 1
@@ -2968,7 +2968,7 @@ Change user's initial leverage of specific symbol market.
 }
 ```
 
-``POST /fapi/v3/positionMargin (HMAC SHA256)``
+``POST /fapi/v3/positionMargin``
 
 **Weight:**
 1
@@ -3011,7 +3011,7 @@ Change user's initial leverage of specific symbol market.
 ]
 ```
 
-``GET /fapi/v3/positionMargin/history (HMAC SHA256)``
+``GET /fapi/v3/positionMargin/history``
 
 **Weight:**
 1
@@ -3091,7 +3091,7 @@ Change user's initial leverage of specific symbol market.
 ]
 ```
 
-``GET /fapi/v3/positionRisk (HMAC SHA256)``
+``GET /fapi/v3/positionRisk``
 
 Get current position information.
 
@@ -3134,7 +3134,7 @@ Please use with user data stream `ACCOUNT_UPDATE` to meet your timeliness and ac
 ]
 ```
 
-``GET /fapi/v3/userTrades  (HMAC SHA256)``
+``GET /fapi/v3/userTrades ``
 
 Get trades for a specific account and symbol.
 
@@ -3186,7 +3186,7 @@ Get trades for a specific account and symbol.
 ]
 ```
 
-``GET /fapi/v3/income (HMAC SHA256)``
+``GET /fapi/v3/income``
 
 **Weight:**
 30
@@ -3393,7 +3393,7 @@ Get trades for a specific account and symbol.
 }
 ```
 
-``GET /fapi/v3/commissionRate (HMAC SHA256)``
+``GET /fapi/v3/commissionRate``
 
 **Weight:**
 20

--- a/V3(Recommended)/EN/aster-finance-spot-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-spot-api-testnet.md
@@ -1032,7 +1032,7 @@ Get symbol fees
 }
 ```
 
-`POST /api/v3/order (HMAC SHA256)`
+`POST /api/v3/order`
 
 Send order
 
@@ -1096,7 +1096,7 @@ Other information:
 }
 ```
 
-`DELETE /api/v3/order (HMAC SHA256)`
+`DELETE /api/v3/order`
 
 Cancel active orders
 
@@ -1139,7 +1139,7 @@ At least one of `orderId` or `origClientOrderId` must be sent.
 } 
 ```
 
-`GET /api/v3/order (HMAC SHA256)`
+`GET /api/v3/order`
 
 Query order status
 
@@ -1191,7 +1191,7 @@ Note:
 ]
 ```
 
-`GET /api/v3/openOrders (HMAC SHA256)`
+`GET /api/v3/openOrders`
 
 Retrieve all current open orders for trading pairs. Use calls without a trading pair parameter with caution.
 
@@ -1222,7 +1222,7 @@ Retrieve all current open orders for trading pairs. Use calls without a trading 
 ```
 
 ``
-DEL /api/v3/allOpenOrders  (HMAC SHA256)
+DEL /api/v3/allOpenOrders 
 ``
 
 **Weight:**
@@ -1266,7 +1266,7 @@ timestamp | LONG | YES |
 ]
 ```
 
-`GET /api/v3/allOrders (HMAC SHA256)`
+`GET /api/v3/allOrders`
 
 Retrieve all account orders; active, canceled, or completed.
 
@@ -1342,7 +1342,7 @@ limit | LONG | NO | default:100 max:1000
 }
 ```
 
-`POST /api/v3/asset/wallet/transfer  (HMAC SHA256)`
+`POST /api/v3/asset/wallet/transfer `
 
 **Weight:** 5
 
@@ -1396,7 +1396,7 @@ asset | STRING | YES |
 ```
 
 ``
-POST /api/v3/aster/user-withdraw (HMAC SHA256)
+POST /api/v3/aster/user-withdraw
 ``
 
 **Weight:**
@@ -1487,7 +1487,7 @@ const signature = await signer.signTypedData(domain, types, value)
 }
 ```
 
-`GET /api/v3/account (HMAC SHA256)`
+`GET /api/v3/account`
 
 Retrieve current account information
 
@@ -1525,7 +1525,7 @@ Retrieve current account information
 ] 
 ```
 
-`GET /api/v3/userTrades (HMAC SHA256)`
+`GET /api/v3/userTrades`
 
 Retrieve the trade history for a specified trading pair of an account
 

--- a/V3(Recommended)/EN/aster-finance-spot-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-spot-api-v3.md
@@ -1013,7 +1013,7 @@ Get symbol fees
 }
 ```
 
-`POST /api/v3/order (HMAC SHA256)`
+`POST /api/v3/order`
 
 Send order
 
@@ -1075,7 +1075,7 @@ Other information:
 }
 ```
 
-`DELETE /api/v3/order (HMAC SHA256)`
+`DELETE /api/v3/order`
 
 Cancel active orders
 
@@ -1116,7 +1116,7 @@ At least one of `orderId` or `origClientOrderId` must be sent.
 } 
 ```
 
-`GET /api/v3/order (HMAC SHA256)`
+`GET /api/v3/order`
 
 Query order status
 
@@ -1164,7 +1164,7 @@ Note:
 }
 ```
 
-`GET /api/v3/openOrder (HMAC SHA256)`
+`GET /api/v3/openOrder`
 
 Query current open order status.
 
@@ -1209,7 +1209,7 @@ Note:
 ]
 ```
 
-`GET /api/v3/openOrders (HMAC SHA256)`
+`GET /api/v3/openOrders`
 
 Retrieve all current open orders for trading pairs. Use calls without a trading pair parameter with caution.
 
@@ -1279,7 +1279,7 @@ origClientOrderIdList | STRING | NO | clientOrderId array string
 ]
 ```
 
-`GET /api/v3/allOrders (HMAC SHA256)`
+`GET /api/v3/allOrders`
 
 Retrieve all account orders; active, canceled, or completed.
 
@@ -1352,7 +1352,7 @@ limit | LONG | NO | default:100 max:1000
 }
 ```
 
-`POST /api/v3/asset/wallet/transfer  (HMAC SHA256)`
+`POST /api/v3/asset/wallet/transfer `
 
 **Weight:** 5
 
@@ -1493,7 +1493,7 @@ const signature = await signer.signTypedData(domain, types, value)
 }
 ```
 
-`GET /api/v3/account (HMAC SHA256)`
+`GET /api/v3/account`
 
 Retrieve current account information
 
@@ -1529,7 +1529,7 @@ Retrieve current account information
 ] 
 ```
 
-`GET /api/v3/userTrades (HMAC SHA256)`
+`GET /api/v3/userTrades`
 
 Retrieve the trade history for a specified trading pair of an account
 


### PR DESCRIPTION
docs: remove HMAC SHA256 labels from V3 API endpoint headings