### PR TITLE
docs: add fapi/v3/stpMode endpoints and stpMode order parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2026-05-21
+
+### Added
+
+#### `POST /fapi/v3/stpMode` — Change STP Mode / 更改STP模式
+
+A new TRADE endpoint that sets the account-level **Self-Trade Prevention (STP) mode** applied to all orders by default. Accepted values: `EXPIRE_TAKER`, `EXPIRE_MAKER`, `EXPIRE_BOTH`.
+
+#### `GET /fapi/v3/stpMode` — Get Current STP Mode / 查询STP模式
+
+A new USER_DATA endpoint that returns the account's current STP mode.
+
+### Changed
+
+#### `POST /fapi/v3/order` — New Order: added optional `stpMode` parameter
+
+Added `stpMode` (ENUM, optional) to the place-order parameter list. When specified, it overrides the account-level STP default for that individual order.
+
+---
+
 ## 2026-05-19
 
 ### Added

--- a/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
@@ -69,6 +69,8 @@
 - [Account/Trades Endpoints](#accounttrades-endpoints)
   - [Change Position Mode(TRADE)](#change-position-modetrade)
   - [Get Current Position Mode(USER_DATA)](#get-current-position-modeuser_data)
+  - [Change STP Mode (TRADE)](#change-stp-modetrade)
+  - [Get Current STP Mode (USER_DATA)](#get-current-stp-modeuser_data)
   - [Change Multi-Assets Mode (TRADE)](#change-multi-assets-mode-trade)
   - [Get Current Multi-Assets Mode (USER_DATA)](#get-current-multi-assets-mode-user_data)
   - [New Order  (TRADE)](#new-order--trade)
@@ -462,6 +464,12 @@ if __name__ == '__main__':
 
 * ACK
 * RESULT
+
+**STP Mode (stpMode)**
+
+* EXPIRE_TAKER
+* EXPIRE_MAKER
+* EXPIRE_BOTH
 
 **Kline/Candlestick chart intervals:**
 
@@ -2081,6 +2089,58 @@ Get user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 | recvWindow | LONG | NO        |             |
 | timestamp  | LONG | YES       |             |
 
+## Change STP Mode (TRADE)
+
+> **Response:**
+
+```javascript
+{
+	"code": 200,
+	"msg": "success"
+}
+```
+
+``POST /fapi/v3/stpMode``
+
+Change user's Self-Trade Prevention (STP) mode on ***EVERY symbol***
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name | Type | Mandatory | Description |
+|------|------|-----------|-------------|
+| stpMode | ENUM | YES | `EXPIRE_TAKER`: expire taker order; `EXPIRE_MAKER`: expire maker order; `EXPIRE_BOTH`: expire both maker and taker orders |
+| nonce | LONG | YES | Microsecond-level timestamp |
+| signer | STRING | YES | API wallet address |
+| signature | STRING | YES | Signature |
+
+## Get Current STP Mode (USER_DATA)
+
+> **Response:**
+
+```javascript
+{
+	"stpMode": "EXPIRE_TAKER" // Current STP mode
+}
+```
+
+``GET /fapi/v3/stpMode``
+
+Get user's current Self-Trade Prevention (STP) mode on ***EVERY symbol***
+
+**Weight:**
+30
+
+**Parameters:**
+
+| Name | Type | Mandatory | Description |
+|------|------|-----------|-------------|
+| nonce | LONG | YES | Microsecond-level timestamp |
+| signer | STRING | YES | API wallet address |
+| signature | STRING | YES | Signature |
+
 ## Change Multi-Assets Mode (TRADE)
 
 > **Response:**
@@ -2193,6 +2253,7 @@ Send in a new order.
 | pegPriceType     | ENUM    | NO        | BBO peg mode: `COUNTERPARTY_1` or `QUEUE_1`. When set on a `LIMIT` order, the engine resolves the actual price from the order book at trigger time using the BBO + `pegOffset`. Defaults to no peg. |
 | pegOffset        | DECIMAL | NO        | Signed offset from BBO when `pegPriceType` is set. BUY orders should use a non-positive value (e.g. `-0.5`); SELL non-negative. Units: same scale as `price` (must be a `tickSize` multiple).        |
 | priceLimit       | DECIMAL | NO        | Absolute price cap for BBO-pegged orders. BUY: ceiling — peg never resolves above this; SELL: floor. Must be > 0 and a multiple of `tickSize`. Defaults to no cap.                                   |
+| stpMode          | ENUM    | NO        | Self-Trade Prevention mode for this order. Overrides the account-level default. `EXPIRE_TAKER`: cancel the taker side; `EXPIRE_MAKER`: cancel the maker side; `EXPIRE_BOTH`: cancel both sides.      |
 | recvWindow       | LONG    | NO        |                                                                                                                                        |
 | timestamp        | LONG    | YES       |                                                                                                                                        |
 

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -68,6 +68,8 @@
 - [Account/Trades Endpoints](#accounttrades-endpoints)
   - [Change Position Mode(TRADE)](#change-position-modetrade)
   - [Get Current Position Mode(USER_DATA)](#get-current-position-modeuser_data)
+  - [Change STP Mode (TRADE)](#change-stp-modetrade)
+  - [Get Current STP Mode (USER_DATA)](#get-current-stp-modeuser_data)
   - [Change Multi-Assets Mode (TRADE)](#change-multi-assets-mode-trade)
   - [Get Current Multi-Assets Mode (USER_DATA)](#get-current-multi-assets-mode-user_data)
   - [New Order  (TRADE)](#new-order--trade)
@@ -467,6 +469,12 @@ if __name__ == '__main__':
 
 * ACK
 * RESULT
+
+**STP Mode (stpMode)**
+
+* EXPIRE_TAKER
+* EXPIRE_MAKER
+* EXPIRE_BOTH
 
 **Kline/Candlestick chart intervals:**
 
@@ -2300,6 +2308,58 @@ Get user's position mode (Hedge Mode or One-way Mode ) on ***EVERY symbol***
 | Name       | Type | Mandatory | Description |
 | ---------- | ---- | --------- | ----------- |
 
+## Change STP Mode (TRADE)
+
+> **Response:**
+
+```javascript
+{
+	"code": 200,
+	"msg": "success"
+}
+```
+
+``POST /fapi/v3/stpMode``
+
+Change user's Self-Trade Prevention (STP) mode on ***EVERY symbol***
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name | Type | Mandatory | Description |
+|------|------|-----------|-------------|
+| stpMode | ENUM | YES | `EXPIRE_TAKER`: expire taker order; `EXPIRE_MAKER`: expire maker order; `EXPIRE_BOTH`: expire both maker and taker orders |
+| nonce | LONG | YES | Microsecond-level timestamp |
+| signer | STRING | YES | API wallet address |
+| signature | STRING | YES | Signature |
+
+## Get Current STP Mode (USER_DATA)
+
+> **Response:**
+
+```javascript
+{
+	"stpMode": "EXPIRE_TAKER" // Current STP mode
+}
+```
+
+``GET /fapi/v3/stpMode``
+
+Get user's current Self-Trade Prevention (STP) mode on ***EVERY symbol***
+
+**Weight:**
+30
+
+**Parameters:**
+
+| Name | Type | Mandatory | Description |
+|------|------|-----------|-------------|
+| nonce | LONG | YES | Microsecond-level timestamp |
+| signer | STRING | YES | API wallet address |
+| signature | STRING | YES | Signature |
+
 ## Change Multi-Assets Mode (TRADE)
 
 > **Response:**
@@ -2408,6 +2468,7 @@ Send in a new order.
 | pegPriceType     | ENUM    | NO        | BBO peg mode: `COUNTERPARTY_1` or `QUEUE_1`. When set on a `LIMIT` order, the engine resolves the actual price from the order book at trigger time using the BBO + `pegOffset`. Defaults to no peg. |
 | pegOffset        | DECIMAL | NO        | Signed offset from BBO when `pegPriceType` is set. BUY orders should use a non-positive value (e.g. `-0.5`); SELL non-negative. Units: same scale as `price` (must be a `tickSize` multiple).        |
 | priceLimit       | DECIMAL | NO        | Absolute price cap for BBO-pegged orders. BUY: ceiling — peg never resolves above this; SELL: floor. Must be > 0 and a multiple of `tickSize`. Defaults to no cap.                                   |
+| stpMode          | ENUM    | NO        | Self-Trade Prevention mode for this order. Overrides the account-level default. `EXPIRE_TAKER`: cancel the taker side; `EXPIRE_MAKER`: cancel the maker side; `EXPIRE_BOTH`: cancel both sides.      |
 
 Additional mandatory parameters based on `type`:
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
@@ -63,6 +63,8 @@
 - [账户和交易接口](#账户和交易接口)
 	- [更改持仓模式(TRADE)](#更改持仓模式trade)
 	- [查询持仓模式(USER_DATA)](#查询持仓模式user_data)
+	- [更改STP模式(TRADE)](#更改stp模式trade)
+	- [查询STP模式(USER_DATA)](#查询stp模式user_data)
 	- [更改联合保证金模式(TRADE)](#更改联合保证金模式trade)
 	- [查询联合保证金模式(USER_DATA)](#查询联合保证金模式user_data)
 	- [下单 (TRADE)](#下单-trade)
@@ -446,6 +448,12 @@ if __name__ == '__main__':
 
 * ACK
 * RESULT
+
+**自成交防止模式 (stpMode)**
+
+* EXPIRE_TAKER 撤销taker订单
+* EXPIRE_MAKER 撤销maker订单
+* EXPIRE_BOTH 同时撤销双方订单
 
 **K线间隔:**
 
@@ -2249,6 +2257,60 @@ GET /fapi/v3/positionSide/dual``
 **权重:**
 30
 
+## 更改STP模式(TRADE)
+
+> **响应:**
+
+```javascript
+{
+	"code": 200,
+	"msg": "success"
+}
+```
+
+``
+POST /fapi/v3/stpMode``
+
+变换用户在 ***所有symbol*** 合约上的STP（自成交防止）模式。
+
+**权重:**
+1
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| stpMode | ENUM | YES | `EXPIRE_TAKER`: 撤销taker订单；`EXPIRE_MAKER`: 撤销maker订单；`EXPIRE_BOTH`: 同时撤销双方订单 |
+| nonce | LONG | YES | 微秒级时间戳 |
+| signer | STRING | YES | API钱包地址 |
+| signature | STRING | YES | 签名 |
+
+## 查询STP模式(USER_DATA)
+
+> **响应:**
+
+```javascript
+{
+	"stpMode": "EXPIRE_TAKER" // 当前STP模式
+}
+```
+
+``
+GET /fapi/v3/stpMode``
+
+查询用户目前在 ***所有symbol*** 合约上的STP（自成交防止）模式。
+
+**权重:**
+30
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| nonce | LONG | YES | 微秒级时间戳 |
+| signer | STRING | YES | API钱包地址 |
+| signature | STRING | YES | 签名 |
+
 ## 更改联合保证金模式(TRADE)
 
 > **响应:**
@@ -2362,6 +2424,7 @@ newOrderRespType | ENUM    | NO       | "ACK", "RESULT", 默认 "ACK"
 pegPriceType     | ENUM    | NO       | BBO peg 模式: `COUNTERPARTY_1` 或 `QUEUE_1`。在 `LIMIT` 订单上设置此参数后，撮合引擎在触发时基于订单簿的 BBO 加 `pegOffset` 解析实际价格。默认不使用 peg。
 pegOffset        | DECIMAL | NO       | 当 `pegPriceType` 已设置时，相对 BBO 的有符号偏移量。买单应为非正值（如 `-0.5`），卖单为非负值。单位与 `price` 相同，必须是 `tickSize` 的倍数。
 priceLimit       | DECIMAL | NO       | BBO peg 订单的绝对价格上下限。买单：上限——peg 不会高于此；卖单：下限。必须 > 0 且为 `tickSize` 倍数。默认无限制。
+stpMode          | ENUM    | NO       | 本订单的自成交防止（STP）模式，覆盖账户级默认设置。`EXPIRE_TAKER`：撤销taker订单；`EXPIRE_MAKER`：撤销maker订单；`EXPIRE_BOTH`：同时撤销双方订单。
 
 根据 order `type`的不同，某些参数强制要求，具体如下:
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -66,6 +66,8 @@
 - [账户和交易接口](#账户和交易接口)
 	- [更改持仓模式(TRADE)](#更改持仓模式trade)
 	- [查询持仓模式(USER_DATA)](#查询持仓模式user_data)
+	- [更改STP模式(TRADE)](#更改stp模式trade)
+	- [查询STP模式(USER_DATA)](#查询stp模式user_data)
 	- [更改联合保证金模式(TRADE)](#更改联合保证金模式trade)
 	- [查询联合保证金模式(USER_DATA)](#查询联合保证金模式user_data)
 	- [下单 (TRADE)](#下单-trade)
@@ -454,6 +456,12 @@ if __name__ == '__main__':
 
 * ACK
 * RESULT
+
+**自成交防止模式 (stpMode)**
+
+* EXPIRE_TAKER 撤销taker订单
+* EXPIRE_MAKER 撤销maker订单
+* EXPIRE_BOTH 同时撤销双方订单
 
 **K线间隔:**
 
@@ -2334,6 +2342,60 @@ GET /fapi/v3/positionSide/dual``
 **权重:**
 30
 
+## 更改STP模式(TRADE)
+
+> **响应:**
+
+```javascript
+{
+	"code": 200,
+	"msg": "success"
+}
+```
+
+``
+POST /fapi/v3/stpMode``
+
+变换用户在 ***所有symbol*** 合约上的STP（自成交防止）模式。
+
+**权重:**
+1
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| stpMode | ENUM | YES | `EXPIRE_TAKER`: 撤销taker订单；`EXPIRE_MAKER`: 撤销maker订单；`EXPIRE_BOTH`: 同时撤销双方订单 |
+| nonce | LONG | YES | 微秒级时间戳 |
+| signer | STRING | YES | API钱包地址 |
+| signature | STRING | YES | 签名 |
+
+## 查询STP模式(USER_DATA)
+
+> **响应:**
+
+```javascript
+{
+	"stpMode": "EXPIRE_TAKER" // 当前STP模式
+}
+```
+
+``
+GET /fapi/v3/stpMode``
+
+查询用户目前在 ***所有symbol*** 合约上的STP（自成交防止）模式。
+
+**权重:**
+30
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| nonce | LONG | YES | 微秒级时间戳 |
+| signer | STRING | YES | API钱包地址 |
+| signature | STRING | YES | 签名 |
+
 ## 更改联合保证金模式(TRADE)
 
 > **响应:**
@@ -2447,6 +2509,7 @@ newOrderRespType | ENUM    | NO       | "ACK", "RESULT", 默认 "ACK"
 pegPriceType     | ENUM    | NO       | BBO peg 模式: `COUNTERPARTY_1` 或 `QUEUE_1`。在 `LIMIT` 订单上设置此参数后，撮合引擎在触发时基于订单簿的 BBO 加 `pegOffset` 解析实际价格。默认不使用 peg。
 pegOffset        | DECIMAL | NO       | 当 `pegPriceType` 已设置时，相对 BBO 的有符号偏移量。买单应为非正值（如 `-0.5`），卖单为非负值。单位与 `price` 相同，必须是 `tickSize` 的倍数。
 priceLimit       | DECIMAL | NO       | BBO peg 订单的绝对价格上下限。买单：上限——peg 不会高于此；卖单：下限。必须 > 0 且为 `tickSize` 倍数。默认无限制。
+stpMode          | ENUM    | NO       | 本订单的自成交防止（STP）模式，覆盖账户级默认设置。`EXPIRE_TAKER`：撤销taker订单；`EXPIRE_MAKER`：撤销maker订单；`EXPIRE_BOTH`：同时撤销双方订单。
 
 根据 order `type`的不同，某些参数强制要求，具体如下:
 


### PR DESCRIPTION
- Add POST/GET /fapi/v3/stpMode (Change/Get STP Mode) to EN and CN futures docs (v3 + testnet)
- Add stpMode TOC entries and ENUM definitions in all four files
- Add optional stpMode parameter to POST /fapi/v3/order parameter table
- Auth params use nonce/signer/signature consistent with v3 auth
- Update CHANGELOG.md