### PR TITLE
fix: use signatureChainId in registerAndApproveAgent typed_data domain

### DIFF
--- a/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
@@ -4037,6 +4037,8 @@ msg: user={user}&nonce={nonce}&agentName={agentName}&agentAddress={agentAddress}
 
 > **EVM addresses only:** wrap the `msg` string above as `message.msg` in the following EIP-712 typed data structure before signing:
 
+> **⚠️ Note:** `domain.chainId` must be set to the value of the request parameter `signatureChainId` (`56` for EVM addresses, `101` for Solana addresses) — do **not** use the fixed value `714`.
+
 ```
 typed_data = {
   "types": {
@@ -4054,7 +4056,7 @@ typed_data = {
   "domain": {
     "name": "AsterSignTransaction",
     "version": "1",
-    "chainId": 714,
+    "chainId": signatureChainId,
     "verifyingContract": "0x0000000000000000000000000000000000000000"
   },
   "message": {
@@ -4067,7 +4069,7 @@ typed_data = {
 
 | Account Type | Signing Algorithm | Encoding |
 |---|---|---|
-| EVM Address | EIP-712 Typed Data (chainId=56, message.msg=message body) | Hex |
+| EVM Address | EIP-712 Typed Data (chainId=signatureChainId, message.msg=message body) | Hex |
 | Solana Address | Ed25519 | Base58 |
 
 ---

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -4552,6 +4552,8 @@ msg: user={user}&nonce={nonce}&agentName={agentName}&agentAddress={agentAddress}
 
 > **EVM addresses only:** wrap the `msg` string above as `message.msg` in the following EIP-712 typed data structure before signing:
 
+> **⚠️ Note:** `domain.chainId` must be set to the value of the request parameter `signatureChainId` (`56` for EVM addresses, `101` for Solana addresses) — do **not** use the fixed value `1666`.
+
 ```
 typed_data = {
   "types": {
@@ -4569,7 +4571,7 @@ typed_data = {
   "domain": {
     "name": "AsterSignTransaction",
     "version": "1",
-    "chainId": 1666,
+    "chainId": signatureChainId,
     "verifyingContract": "0x0000000000000000000000000000000000000000"
   },
   "message": {
@@ -4582,7 +4584,7 @@ typed_data = {
 
 | Account Type | Signing Algorithm | Encoding |
 |---|---|---|
-| EVM Address | EIP-712 Typed Data (chainId=56, message.msg=message body) | Hex |
+| EVM Address | EIP-712 Typed Data (chainId=signatureChainId, message.msg=message body) | Hex |
 | Solana Address | Ed25519 | Base58 |
 
 ---

--- a/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
@@ -4271,6 +4271,8 @@ msg: user={user}&nonce={nonce}&agentName={agentName}&agentAddress={agentAddress}
 
 > **EVM 地址专用：** 将上述 `msg` 字符串作为 EIP-712 结构化数据中 `message.msg` 的值进行签名，结构如下：
 
+> **⚠️ 注意：** `domain.chainId` 必须使用请求参数 `signatureChainId` 的值（EVM 地址填 `56`，Solana 地址填 `101`），而非固定值 `714`。
+
 ```
 typed_data = {
   "types": {
@@ -4288,7 +4290,7 @@ typed_data = {
   "domain": {
     "name": "AsterSignTransaction",
     "version": "1",
-    "chainId": 714,
+    "chainId": signatureChainId,
     "verifyingContract": "0x0000000000000000000000000000000000000000"
   },
   "message": {
@@ -4301,7 +4303,7 @@ typed_data = {
 
 | 账户类型 | 签名算法 | 编码格式 |
 |---|---|---|
-| EVM 地址 | EIP-712 Typed Data（chainId=56，message.msg=消息体） | Hex |
+| EVM 地址 | EIP-712 Typed Data（chainId=signatureChainId，message.msg=消息体） | Hex |
 | Solana 地址 | Ed25519 | Base58 |
 
 ---

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -4713,6 +4713,8 @@ msg: user={user}&nonce={nonce}&agentName={agentName}&agentAddress={agentAddress}
 
 > **EVM 地址专用：** 将上述 `msg` 字符串作为 EIP-712 结构化数据中 `message.msg` 的值进行签名，结构如下：
 
+> **⚠️ 注意：** `domain.chainId` 必须使用请求参数 `signatureChainId` 的值（EVM 地址填 `56`，Solana 地址填 `101`），而非固定值 `1666`。
+
 ```
 typed_data = {
   "types": {
@@ -4730,7 +4732,7 @@ typed_data = {
   "domain": {
     "name": "AsterSignTransaction",
     "version": "1",
-    "chainId": 1666,
+    "chainId": signatureChainId,
     "verifyingContract": "0x0000000000000000000000000000000000000000"
   },
   "message": {
@@ -4743,7 +4745,7 @@ typed_data = {
 
 | 账户类型 | 签名算法 | 编码格式 |
 |---|---|---|
-| EVM 地址 | EIP-712 Typed Data（chainId=56，message.msg=消息体） | Hex |
+| EVM 地址 | EIP-712 Typed Data（chainId=signatureChainId，message.msg=消息体） | Hex |
 | Solana 地址 | Ed25519 | Base58 |
 
 ---


### PR DESCRIPTION
Replace hardcoded chainId=1666 with signatureChainId variable in the EIP-712 typed_data domain for registerAndApproveAgent. Add warning note clarifying that domain.chainId must match the signatureChainId request parameter (56 for EVM, 101 for Solana).