### PR TITLE
docs: add GET /fapi/v3/builder/userTrades and /fapi/v3/builder/approv…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-07-03
+
+### Added
+
+#### `GET /fapi/v3/builder/userTrades` — Get Builder Trades
+
+New USER_DATA endpoint (weight 5) returning the paginated trade history of users trading under the caller's builder code, with `startTime`/`endTime`/`page`/`limit` filters.
+
+#### `GET /fapi/v3/builder/approvedUserList` — Get Builder Approved User List
+
+New USER_DATA endpoint (weight 5) returning the list of users who have approved the caller's address as their builder, with an optional `startTime` filter.
+
+---
+
 ## 2026-06-30
 
 ### Changed

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -116,6 +116,8 @@
   - [Register and Approve Agent (PUBLIC)](#register-and-approve-agent-public)
   - [Get Direct Announcements (USER_DATA)](#get-direct-announcements-user_data)
   - [Get Direct Announcement By ID (USER_DATA)](#get-direct-announcement-by-id-user_data)
+  - [Get Builder Trades (USER_DATA)](#get-builder-trades-user_data)
+  - [Get Builder Approved User List (USER_DATA)](#get-builder-approved-user-list-user_data)
 - [User Data Streams](#user-data-streams)
   - [Start User Data Stream (USER_STREAM)](#start-user-data-stream-user_stream)
   - [Keepalive User Data Stream (USER_STREAM)](#keepalive-user-data-stream-user_stream)
@@ -4716,6 +4718,144 @@ Retrieves a single direct announcement by its ID for the authenticated user.
 | category | STRING | Announcement category |
 | publishTime | LONG | Publish timestamp (milliseconds) |
 | jumpLink | STRING | Link to the full announcement page |
+
+---
+
+# Get Builder Trades (USER_DATA)
+
+> **Response:**
+
+```javascript
+{
+  "total": 42,
+  "currentPage": 1,
+  "totalPages": 1,
+  "pageSize": 50,
+  "hasMore": false,
+  "rows": [
+    {
+      "tradeId": 698759,
+      "insertTime": 1751500000000,
+      "symbol": "BTCUSDT",
+      "positionSide": "SHORT",
+      "price": "7819.01",
+      "qty": "0.002",
+      "baseAsset": "BTC",
+      "baseType": "CRYPTO",
+      "quoteAsset": "USDT",
+      "side": "SELL",
+      "activeBuy": false,
+      "feeAsset": "USDT",
+      "totalQuota": "15.63802",
+      "fee": "-0.07819010",
+      "productName": null,
+      "orderId": 25851813,
+      "realizedProfit": "-0.91539999",
+      "marginAsset": "USDT",
+      "userAddress": "0x1234...abcd",
+      "builderFee": "0.00050000"
+    }
+  ]
+}
+```
+
+`GET /fapi/v3/builder/userTrades`
+
+Query the paginated trade history of users trading under the caller's builder code. The authenticated account is used as the builder identity — there is no separate `builder` address parameter.
+
+**Weight:** 5
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| startTime | LONG | NO | Timestamp in ms |
+| endTime | LONG | NO | Timestamp in ms |
+| page | INT | NO | Page number, starting from `1`. Default: `1` |
+| limit | INT | NO | Number of results per page. Default `50`; max `1000` |
+| nonce | LONG | YES | Microsecond-level timestamp, used for replay attack prevention |
+| signer | STRING | YES | Signer address associated with the authenticated account |
+| signature | STRING | YES | Signature over the request body |
+
+* If neither `startTime` nor `endTime` is sent, the recent 7 days' data is returned.
+* The resolved `startTime` must not be earlier than 30 days before the current time, or the request is rejected.
+* `endTime` cannot be more than 1 day ahead of the current server time.
+* Results are ordered by trade time descending.
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| total | LONG | Total number of matching trades |
+| currentPage | INT | Current page number |
+| totalPages | INT | Total number of pages |
+| pageSize | INT | Number of records per page |
+| hasMore | BOOLEAN | Whether more pages are available |
+| rows | ARRAY | List of trade records |
+| rows[].tradeId | LONG | Trade ID |
+| rows[].insertTime | LONG | Trade time (milliseconds) |
+| rows[].symbol | STRING | Symbol |
+| rows[].positionSide | STRING | Position side: `BOTH`, `LONG`, `SHORT` |
+| rows[].price | STRING | Trade price |
+| rows[].qty | STRING | Trade quantity |
+| rows[].baseAsset | STRING | Base asset |
+| rows[].baseType | STRING | Symbol type: `CRYPTO` or `STOCK` |
+| rows[].quoteAsset | STRING | Quote asset |
+| rows[].side | STRING | Trade side |
+| rows[].activeBuy | BOOLEAN | Whether the trade was an active buy |
+| rows[].feeAsset | STRING | Commission asset |
+| rows[].totalQuota | STRING | Notional value of the trade (price × qty) |
+| rows[].fee | STRING | Commission paid (negative value) |
+| rows[].orderId | LONG | Order ID |
+| rows[].realizedProfit | STRING | Realized profit |
+| rows[].marginAsset | STRING | Margin (settlement) asset |
+| rows[].userAddress | STRING | Wallet address of the trading user |
+| rows[].builderFee | STRING | Builder fee charged on the trade |
+
+---
+
+# Get Builder Approved User List (USER_DATA)
+
+> **Response:**
+
+```javascript
+[
+  {
+    "userAddress": "0x1234...abcd",
+    "builderAddress": "0x5678...efgh",
+    "maxFeeRate": 0.0001,
+    "builderName": "MyBuilder",
+    "approveTime": "2026-07-03T10:00:00.000+00:00"
+  }
+]
+```
+
+`GET /fapi/v3/builder/approvedUserList`
+
+Query the list of users who have approved the caller's address as their builder.
+
+**Weight:** 5
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| startTime | LONG | NO | Only return users approved after this timestamp (ms). If omitted, defaults to `0`, meaning no time filter is applied and all approved users are returned. |
+| nonce | LONG | YES | Microsecond-level timestamp, used for replay attack prevention |
+| signer | STRING | YES | Signer address associated with the authenticated account |
+| signature | STRING | YES | Signature over the request body |
+
+* The authenticated account is used as the builder identity — there is no separate `builder` address parameter.
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| userAddress | STRING | Wallet address of the approved user |
+| builderAddress | STRING | Builder's wallet address |
+| maxFeeRate | DECIMAL | Maximum fee rate the user granted this builder |
+| builderName | STRING | Builder name set by the user when approving |
+| approveTime | STRING | ISO-8601 timestamp when the user approved the builder |
 
 ---
 

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -4846,6 +4846,7 @@ Query the list of users who have approved the caller's address as their builder.
 | signature | STRING | YES | Signature over the request body |
 
 * The authenticated account is used as the builder identity — there is no separate `builder` address parameter.
+* Returns at most 1000 records.
 
 **Response Fields:**
 

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -4747,8 +4747,7 @@ Retrieves a single direct announcement by its ID for the authenticated user.
       "activeBuy": false,
       "feeAsset": "USDT",
       "totalQuota": "15.63802",
-      "fee": "-0.07819010",
-      "productName": null,
+      "fee": "0.07819010",
       "orderId": 25851813,
       "realizedProfit": "-0.91539999",
       "marginAsset": "USDT",
@@ -4805,7 +4804,7 @@ Query the paginated trade history of users trading under the caller's builder co
 | rows[].activeBuy | BOOLEAN | Whether the trade was an active buy |
 | rows[].feeAsset | STRING | Commission asset |
 | rows[].totalQuota | STRING | Notional value of the trade (price × qty) |
-| rows[].fee | STRING | Commission paid (negative value) |
+| rows[].fee | STRING | Commission paid |
 | rows[].orderId | LONG | Order ID |
 | rows[].realizedProfit | STRING | Realized profit |
 | rows[].marginAsset | STRING | Margin (settlement) asset |
@@ -4825,7 +4824,7 @@ Query the paginated trade history of users trading under the caller's builder co
     "builderAddress": "0x5678...efgh",
     "maxFeeRate": 0.0001,
     "builderName": "MyBuilder",
-    "approveTime": "2026-07-03T10:00:00.000+00:00"
+    "approveTime": 1768903037082
   }
 ]
 ```
@@ -4856,7 +4855,7 @@ Query the list of users who have approved the caller's address as their builder.
 | builderAddress | STRING | Builder's wallet address |
 | maxFeeRate | DECIMAL | Maximum fee rate the user granted this builder |
 | builderName | STRING | Builder name set by the user when approving |
-| approveTime | STRING | ISO-8601 timestamp when the user approved the builder |
+| approveTime | LONG | Timestamp (ms) when the user approved the builder |
 
 ---
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -5007,6 +5007,7 @@ typed_data = {
 | signature | STRING | YES | 对请求体的签名 |
 
 * 以已认证账户本身作为Builder身份，无需单独传入`builder`地址参数。
+* 最多返回1000条记录。
 
 **响应字段:**
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -114,6 +114,8 @@
 	- [注册并授权 Agent (PUBLIC)](#注册并授权-agent-public)		
 	- [查询直发公告列表 (USER_DATA)](#查询直发公告列表-user_data)
 	- [按ID查询直发公告 (USER_DATA)](#按id查询直发公告-user_data)
+	- [查询Builder交易记录 (USER_DATA)](#查询builder交易记录-user_data)
+	- [查询Builder已授权用户列表 (USER_DATA)](#查询builder已授权用户列表-user_data)
 - [Websocket 账户信息推送](#websocket-账户信息推送)
 	- [生成listenKey (USER_STREAM)](#生成listenkey-user_stream)
 	- [延长listenKey有效期 (USER_STREAM)](#延长listenkey有效期-user_stream)
@@ -4876,6 +4878,145 @@ typed_data = {
 | category | STRING | 公告分类 |
 | publishTime | LONG | 发布时间戳（毫秒） |
 | jumpLink | STRING | 公告详情页链接 |
+
+---
+
+# 查询Builder交易记录 (USER_DATA)
+
+> **响应:**
+
+```javascript
+{
+  "total": 42,
+  "currentPage": 1,
+  "totalPages": 1,
+  "pageSize": 50,
+  "hasMore": false,
+  "rows": [
+    {
+      "tradeId": 698759,
+      "insertTime": 1751500000000,
+      "symbol": "BTCUSDT",
+      "positionSide": "SHORT",
+      "price": "7819.01",
+      "qty": "0.002",
+      "baseAsset": "BTC",
+      "baseType": "CRYPTO",
+      "quoteAsset": "USDT",
+      "side": "SELL",
+      "activeBuy": false,
+      "feeAsset": "USDT",
+      "totalQuota": "15.63802",
+      "fee": "-0.07819010",
+      "productName": null,
+      "orderId": 25851813,
+      "realizedProfit": "-0.91539999",
+      "marginAsset": "USDT",
+      "userAddress": "0x1234...abcd",
+      "builderFee": "0.00050000"
+    }
+  ]
+}
+```
+
+`GET /fapi/v3/builder/userTrades`
+
+查询在当前调用者的Builder代码下交易的用户成交历史，支持分页。以已认证账户本身作为Builder身份，无需单独传入`builder`地址参数。
+
+**权重:** 5
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| startTime | LONG | NO | 起始时间戳（毫秒） |
+| endTime | LONG | NO | 结束时间戳（毫秒） |
+| page | INT | NO | 页码，从 `1` 开始。默认: `1` |
+| limit | INT | NO | 每页返回数量。默认 `50`；最大 `1000` |
+| nonce | LONG | YES | 微秒级时间戳，用于防重放攻击 |
+| signer | STRING | YES | 与当前认证账户关联的 signer 地址 |
+| signature | STRING | YES | 对请求体的签名 |
+
+* 如果 `startTime` 和 `endTime` 都未发送，则返回最近7天的数据。
+* 最终生效的 `startTime` 不能早于当前时间之前30天，否则请求会被拒绝。
+* `endTime` 不能超过当前服务器时间1天以上。
+* 结果按成交时间倒序排列。
+
+**响应字段:**
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| total | LONG | 符合条件的成交总数 |
+| currentPage | INT | 当前页码 |
+| totalPages | INT | 总页数 |
+| pageSize | INT | 每页数量 |
+| hasMore | BOOLEAN | 是否还有下一页 |
+| rows | ARRAY | 成交记录列表 |
+| rows[].tradeId | LONG | 成交ID |
+| rows[].insertTime | LONG | 成交时间（毫秒） |
+| rows[].symbol | STRING | 交易对 |
+| rows[].positionSide | STRING | 持仓方向：`BOTH`、`LONG`、`SHORT` |
+| rows[].price | STRING | 成交价格 |
+| rows[].qty | STRING | 成交数量 |
+| rows[].baseAsset | STRING | 基础资产 |
+| rows[].baseType | STRING | 标的类型：`CRYPTO` 或 `STOCK` |
+| rows[].quoteAsset | STRING | 计价资产 |
+| rows[].side | STRING | 买卖方向 |
+| rows[].activeBuy | BOOLEAN | 是否为主动买入 |
+| rows[].feeAsset | STRING | 手续费资产 |
+| rows[].totalQuota | STRING | 成交名义价值（价格 × 数量） |
+| rows[].fee | STRING | 手续费（负值） |
+| rows[].productName | STRING | 当前接口暂未填充该字段（始终为 `null`） |
+| rows[].orderId | LONG | 订单ID |
+| rows[].realizedProfit | STRING | 已实现盈亏 |
+| rows[].marginAsset | STRING | 保证金（结算）资产 |
+| rows[].userAddress | STRING | 交易用户的钱包地址 |
+| rows[].builderFee | STRING | 该笔成交收取的Builder手续费 |
+
+---
+
+# 查询Builder已授权用户列表 (USER_DATA)
+
+> **响应:**
+
+```javascript
+[
+  {
+    "userAddress": "0x1234...abcd",
+    "builderAddress": "0x5678...efgh",
+    "maxFeeRate": 0.0001,
+    "builderName": "MyBuilder",
+    "approveTime": "2026-07-03T10:00:00.000+00:00"
+  }
+]
+```
+
+`GET /fapi/v3/builder/approvedUserList`
+
+查询已将当前调用者地址授权为Builder的用户列表。
+
+**权重:** 5
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| startTime | LONG | NO | 仅返回该时间戳（毫秒）之后授权的用户。若不传，默认为 `0`，即不做时间过滤，返回全部已授权用户 |
+| nonce | LONG | YES | 微秒级时间戳，用于防重放攻击 |
+| signer | STRING | YES | 与当前认证账户关联的 signer 地址 |
+| signature | STRING | YES | 对请求体的签名 |
+
+* 以已认证账户本身作为Builder身份，无需单独传入`builder`地址参数。
+
+**响应字段:**
+
+| 字段 | 类型 | 描述 |
+|------|------|------|
+| userAddress | STRING | 被授权用户的钱包地址 |
+| builderAddress | STRING | Builder的钱包地址 |
+| maxFeeRate | DECIMAL | 用户授权给该Builder的最大手续费率 |
+| builderName | STRING | 用户授权时设置的Builder名称 |
+| approveTime | STRING | 用户授权Builder的时间（ISO-8601格式） |
 
 ---
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -4907,8 +4907,7 @@ typed_data = {
       "activeBuy": false,
       "feeAsset": "USDT",
       "totalQuota": "15.63802",
-      "fee": "-0.07819010",
-      "productName": null,
+      "fee": "0.07819010",
       "orderId": 25851813,
       "realizedProfit": "-0.91539999",
       "marginAsset": "USDT",
@@ -4965,8 +4964,7 @@ typed_data = {
 | rows[].activeBuy | BOOLEAN | 是否为主动买入 |
 | rows[].feeAsset | STRING | 手续费资产 |
 | rows[].totalQuota | STRING | 成交名义价值（价格 × 数量） |
-| rows[].fee | STRING | 手续费（负值） |
-| rows[].productName | STRING | 当前接口暂未填充该字段（始终为 `null`） |
+| rows[].fee | STRING | 手续费 |
 | rows[].orderId | LONG | 订单ID |
 | rows[].realizedProfit | STRING | 已实现盈亏 |
 | rows[].marginAsset | STRING | 保证金（结算）资产 |
@@ -4986,7 +4984,7 @@ typed_data = {
     "builderAddress": "0x5678...efgh",
     "maxFeeRate": 0.0001,
     "builderName": "MyBuilder",
-    "approveTime": "2026-07-03T10:00:00.000+00:00"
+    "approveTime": 1768903037082
   }
 ]
 ```
@@ -5017,7 +5015,7 @@ typed_data = {
 | builderAddress | STRING | Builder的钱包地址 |
 | maxFeeRate | DECIMAL | 用户授权给该Builder的最大手续费率 |
 | builderName | STRING | 用户授权时设置的Builder名称 |
-| approveTime | STRING | 用户授权Builder的时间（ISO-8601格式） |
+| approveTime | LONG | 用户授权Builder的时间戳（毫秒） |
 
 ---
 


### PR DESCRIPTION
…edUserList (EN + CN)

Documents the two new builder query endpoints based on cloud-me-rest and downstream service source, including the maxFeeRate fix in getApproveBuilderUserInfos and the common nonce/signer/signature params.