### PR TITLE
docs(sub-account transfer): clarify master account terminology and ad…

### DIFF
--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -241,7 +241,7 @@ It is strongly recommended to use websocket stream for getting data as much as p
 
 | Parameter | Description                        |
 | --------- | ---------------------------------- |
-| user      | Main account wallet address        |
+| user      | Master account wallet address      |
 | signer    | API wallet address                 |
 | nonce     | Current timestamp, in microseconds |
 | signature | Signature                          |
@@ -4351,9 +4351,19 @@ subSourceAddr={subSourceAddr}&nonce={nonce}&user={user}&signer={signer}[&subAcco
 | kindType | ENUM | YES | Transfer direction (see table below) |
 | nonce | LONG | YES | Microsecond-level timestamp, used for replay attack prevention |
 | user | STRING | YES | Signing account wallet address (master account address in most cases; sub-account address when the sub-account initiates a transfer to the master account) |
-| signer | STRING | YES | Signer address associated with `user` |
 | fromAccountAddress | STRING | NO | Source wallet address. Required when the source account differs from `user` (e.g., sub→sub transfers or master→sub transfers initiated by a third party) |
 | signature | STRING | YES | Signature over the message body, **must be signed using the `user` account's wallet private key** (see Signature Instructions below) |
+
+
+**`Parameter Values`:**
+
+| Transfer | user | fromAccountAddress | toAccountAddress | signature |
+|------|------|------|------|------
+| Master → Sub | Master account address | Master account address | Sub-account address | Signed with master account private key
+| Sub → Master | Master account address | Sub-account address | Master account address | Signed with master account private key
+| Sub → Sub | Master account address | Sub A address | Sub B address | Signed with master account private key
+| Sub → Master | Sub-account address | Sub-account address | Master account address | Signed with sub-account private key
+| Sub → Sub | Sub A address | Sub A address | Sub B address | Signed with sub-account private key
 
 **`kindType` values:**
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -232,7 +232,7 @@ MARKET_DATA | 不需要鉴权的接口
 ## 鉴权签名体
 参数 | 描述
 ------------ | ------------
-user | 主账户钱包地址
+user | 母账户钱包地址
 signer | API钱包地址
 nonce | 当前时间戳,单位为微秒
 signature | 签名
@@ -4507,9 +4507,19 @@ subSourceAddr={subSourceAddr}&nonce={nonce}&user={user}&signer={signer}[&subAcco
 | kindType | ENUM | YES | 划转方向（见下表） |
 | nonce | LONG | YES | 微秒级时间戳，用于防重放攻击 |
 | user | STRING | YES | 签名账户的钱包地址（通常为母账户地址；子账户向母账户划转时为子账户地址） |
-| signer | STRING | YES | 与 `user` 关联的 signer 地址 |
 | fromAccountAddress | STRING | NO | 转出钱包地址。当转出账户与 `user` 不一致时必传（如子→子划转，或以第三方身份发起的母→子划转） |
 | signature | STRING | YES | 对消息体的签名，**必须使用 `user` 账户的钱包私钥签名**（见下方签名说明） |
+
+
+**`参数取值` :**
+
+| 转账  | user | fromAccountAddress | toAccountAddress | signature |
+|------|------|------|------|------
+| 母账户转子账户 | 母账户地址 | 母账户地址| 子账户地址 | 使用母账户地址私钥
+| 子账户转母账户 | 母账户地址 | 子账户地址| 母账户地址 | 使用母账户地址私钥
+| 子账户转子账户 | 母账户地址 | 子账户地址A| 子账户地址B | 使用母账户地址私钥
+| 子账户转母账户 | 子账户地址 | 子账户地址| 母账户地址 | 使用子账户地址私钥
+| 子账户转子账户 | 子账户地址A | 子账户地址A| 子账户地址B | 使用子账户地址私钥
 
 **`kindType` 取值:**
 


### PR DESCRIPTION
…d parameter scenarios table (EN + CN)

Rename ambiguous "主账户/main account" to "母账户/master account" and document the user/fromAccountAddress/toAccountAddress/signature combinations for each transfer direction.