### PR TITLE
guard_prod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-07-07
+
+### Added
+
+#### `DELETE /fapi/v3/guardedCancelOrder` and `DELETE /fapi/v3/guardedBatchOrders` — Cancel Order / Cancel Multiple Orders (Guarded)
+
+Added guarded variants of the existing cancel endpoints, intended for orders placed/authorized on-chain — the on-chain nonce associated with each order guards against duplicate or out-of-order cancellation. Require `signer`, `nonce`, and `signature`; other request parameters and the response schema are identical to `DELETE /fapi/v3/order` and `DELETE /fapi/v3/batchOrders` respectively.
+
+Documented in EN and CN, mainnet and testnet futures API references.
+
+---
+
 ## 2026-07-03
 
 ### Added

--- a/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
@@ -79,8 +79,10 @@
   - [Transfer Between Futures And Spot (USER_DATA)](#transfer-between-futures-and-spot-user_data)
   - [Query Order (USER_DATA)](#query-order-user_data)
   - [Cancel Order (TRADE)](#cancel-order-trade)
+  - [Cancel Order (Guarded) (TRADE)](#cancel-order-guarded-trade)
   - [Cancel All Open Orders (TRADE)](#cancel-all-open-orders-trade)
   - [Cancel Multiple Orders (TRADE)](#cancel-multiple-orders-trade)
+  - [Cancel Multiple Orders (Guarded) (TRADE)](#cancel-multiple-orders-guarded-trade)
   - [Auto-Cancel All Open Orders (TRADE)](#auto-cancel-all-open-orders-trade)
   - [Query Current Open Order (USER_DATA)](#query-current-open-order-user_data)
   - [Current All Open Orders (USER_DATA)](#current-all-open-orders-user_data)
@@ -2644,6 +2646,59 @@ Cancel an active order.
 
 Either `orderId` or `origClientOrderId` must be sent.
 
+## Cancel Order (Guarded) (TRADE)
+
+> **Response:**
+
+```javascript
+{
+ 	"clientOrderId": "myOrder1",
+ 	"cumQty": "0",
+ 	"cumQuote": "0",
+ 	"executedQty": "0",
+ 	"orderId": 283194212,
+ 	"origQty": "11",
+ 	"origType": "TRAILING_STOP_MARKET",
+  	"price": "0",
+  	"reduceOnly": false,
+  	"side": "BUY",
+  	"positionSide": "SHORT",
+  	"status": "CANCELED",
+  	"stopPrice": "9300",				// please ignore when order type is TRAILING_STOP_MARKET
+  	"closePosition": false,   // if Close-All
+  	"symbol": "BTCUSDT",
+  	"timeInForce": "GTC",
+  	"type": "TRAILING_STOP_MARKET",
+  	"activatePrice": "9020",			// activation price, only return with TRAILING_STOP_MARKET order
+  	"priceRate": "0.3",					// callback rate, only return with TRAILING_STOP_MARKET order
+ 	"updateTime": 1571110484038,
+ 	"workingType": "CONTRACT_PRICE",
+ 	"priceProtect": false            // if conditional order trigger is protected
+}
+```
+
+``DELETE /fapi/v3/guardedCancelOrder ``
+
+Cancel an active order. Guarded variant of `DELETE /fapi/v3/order`, intended for orders placed/authorized on-chain: the on-chain nonce associated with the order is used to guard against duplicate or out-of-order cancellation. `signer`, `nonce`, and `signature` are required. Other request parameters and the response are identical to `DELETE /fapi/v3/order`.
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name              | Type   | Mandatory | Description |
+| ----------------- | ------ | --------- | ----------- |
+| symbol            | STRING | YES       |             |
+| orderId           | LONG   | NO        |             |
+| origClientOrderId | STRING | NO        |             |
+| recvWindow        | LONG   | NO        |             |
+| timestamp         | LONG   | YES       |             |
+| signer            | STRING | YES       | API wallet address |
+| nonce             | LONG   | YES       | The `nonce` that was used to place this order (i.e. the `nonce` submitted with `POST /fapi/v3/order`), not a new/current timestamp |
+| signature         | STRING | YES       | EIP-712 signature signed with the `signer` wallet private key |
+
+Either `orderId` or `origClientOrderId` must be sent.
+
 ## Cancel All Open Orders (TRADE)
 
 > **Response:**
@@ -2721,6 +2776,65 @@ Either `orderId` or `origClientOrderId` must be sent.
 | timestamp             | LONG           | YES       |                                                                                                 |
 
 Either `orderIdList` or `origClientOrderIdList ` must be sent.
+
+## Cancel Multiple Orders (Guarded) (TRADE)
+
+> **Response:**
+
+```javascript
+[
+	{
+	 	"clientOrderId": "myOrder1",
+	 	"cumQty": "0",
+	 	"cumQuote": "0",
+	 	"executedQty": "0",
+	 	"orderId": 283194212,
+	 	"origQty": "11",
+	 	"origType": "TRAILING_STOP_MARKET",
+  		"price": "0",
+  		"reduceOnly": false,
+  		"side": "BUY",
+  		"positionSide": "SHORT",
+  		"status": "CANCELED",
+  		"stopPrice": "9300",				// please ignore when order type is TRAILING_STOP_MARKET
+  		"closePosition": false,   // if Close-All
+  		"symbol": "BTCUSDT",
+  		"timeInForce": "GTC",
+  		"type": "TRAILING_STOP_MARKET",
+  		"activatePrice": "9020",			// activation price, only return with TRAILING_STOP_MARKET order
+  		"priceRate": "0.3",					// callback rate, only return with TRAILING_STOP_MARKET order
+	 	"updateTime": 1571110484038,
+	 	"workingType": "CONTRACT_PRICE",
+	 	"priceProtect": false            // if conditional order trigger is protected
+	},
+	{
+		"code": -2011,
+		"msg": "Unknown order sent."
+	}
+]
+```
+
+``DELETE /fapi/v3/guardedBatchOrders ``
+
+Cancel multiple active orders. Guarded variant of `DELETE /fapi/v3/batchOrders`, intended for orders placed/authorized on-chain: the on-chain nonce associated with each order is used to guard against duplicate or out-of-order cancellation. `signer`, `nonce`, and `signature` are required. Other request parameters and the response are identical to `DELETE /fapi/v3/batchOrders`.
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name                  | Type           | Mandatory | Description                                                                                     |
+| --------------------- | -------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| symbol                | STRING         | YES       |                                                                                                 |
+| orderIdList           | LIST\   | NO        | max length 10 e.g. [1234567,2345678]                                                      |
+| origClientOrderIdList | LIST\ | NO        | max length 10 e.g. ["my_id_1","my_id_2"], encode the double quotes. No space after comma. |
+| recvWindow            | LONG           | NO        |                                                                                                 |
+| timestamp             | LONG           | YES       |                                                                                                 |
+| signer                | STRING         | YES       | API wallet address |
+| nonce                 | LONG           | YES       | The `nonce` that was used to place these orders (i.e. the `nonce` submitted with `POST /fapi/v3/batchOrders`), not a new/current timestamp |
+| signature             | STRING         | YES       | EIP-712 signature signed with the `signer` wallet private key |
+
+Either `orderIdList` or `origClientOrderIdList` must be sent.
 
 ## Auto-Cancel All Open Orders (TRADE)
 

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -79,8 +79,10 @@
   - [Transfer Between Futures And Spot (USER_DATA)](#transfer-between-futures-and-spot-user_data)
   - [Query Order (USER_DATA)](#query-order-user_data)
   - [Cancel Order (TRADE)](#cancel-order-trade)
+  - [Cancel Order (Guarded) (TRADE)](#cancel-order-guarded-trade)
   - [Cancel All Open Orders (TRADE)](#cancel-all-open-orders-trade)
   - [Cancel Multiple Orders (TRADE)](#cancel-multiple-orders-trade)
+  - [Cancel Multiple Orders (Guarded) (TRADE)](#cancel-multiple-orders-guarded-trade)
   - [Auto-Cancel All Open Orders (TRADE)](#auto-cancel-all-open-orders-trade)
   - [Query Current Open Order (USER_DATA)](#query-current-open-order-user_data)
   - [Current All Open Orders (USER_DATA)](#current-all-open-orders-user_data)
@@ -2859,6 +2861,57 @@ Cancel an active order.
 
 Either `orderId` or `origClientOrderId` must be sent.
 
+## Cancel Order (Guarded) (TRADE)
+
+> **Response:**
+
+```javascript
+{
+ 	"clientOrderId": "myOrder1",
+ 	"cumQty": "0",
+ 	"cumQuote": "0",
+ 	"executedQty": "0",
+ 	"orderId": 283194212,
+ 	"origQty": "11",
+ 	"origType": "TRAILING_STOP_MARKET",
+  	"price": "0",
+  	"reduceOnly": false,
+  	"side": "BUY",
+  	"positionSide": "SHORT",
+  	"status": "CANCELED",
+  	"stopPrice": "9300",				// please ignore when order type is TRAILING_STOP_MARKET
+  	"closePosition": false,   // if Close-All
+  	"symbol": "BTCUSDT",
+  	"timeInForce": "GTC",
+  	"type": "TRAILING_STOP_MARKET",
+  	"activatePrice": "9020",			// activation price, only return with TRAILING_STOP_MARKET order
+  	"priceRate": "0.3",					// callback rate, only return with TRAILING_STOP_MARKET order
+ 	"updateTime": 1571110484038,
+ 	"workingType": "CONTRACT_PRICE",
+ 	"priceProtect": false            // if conditional order trigger is protected
+}
+```
+
+``DELETE /fapi/v3/guardedCancelOrder ``
+
+Cancel an active order. Guarded variant of `DELETE /fapi/v3/order`, intended for orders placed/authorized on-chain: the on-chain nonce associated with the order is used to guard against duplicate or out-of-order cancellation. `signer`, `nonce`, and `signature` are required. Other request parameters and the response are identical to `DELETE /fapi/v3/order`.
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name              | Type   | Mandatory | Description |
+| ----------------- | ------ | --------- | ----------- |
+| symbol            | STRING | YES       |             |
+| orderId           | LONG   | NO        |             |
+| origClientOrderId | STRING | NO        |             |
+| signer            | STRING | YES       | API wallet address |
+| nonce             | LONG   | YES       | The `nonce` that was used to place this order (i.e. the `nonce` submitted with `POST /fapi/v3/order`), not a new/current timestamp |
+| signature         | STRING | YES       | EIP-712 signature signed with the `signer` wallet private key |
+
+Either `orderId` or `origClientOrderId` must be sent.
+
 ## Cancel All Open Orders (TRADE)
 
 > **Response:**
@@ -2932,6 +2985,63 @@ Either `orderId` or `origClientOrderId` must be sent.
 | origClientOrderIdList | LIST\ | NO        | max length 10 e.g. ["my_id_1","my_id_2"], encode the double quotes. No space after comma. |
 
 Either `orderIdList` or `origClientOrderIdList ` must be sent.
+
+## Cancel Multiple Orders (Guarded) (TRADE)
+
+> **Response:**
+
+```javascript
+[
+	{
+	 	"clientOrderId": "myOrder1",
+	 	"cumQty": "0",
+	 	"cumQuote": "0",
+	 	"executedQty": "0",
+	 	"orderId": 283194212,
+	 	"origQty": "11",
+	 	"origType": "TRAILING_STOP_MARKET",
+  		"price": "0",
+  		"reduceOnly": false,
+  		"side": "BUY",
+  		"positionSide": "SHORT",
+  		"status": "CANCELED",
+  		"stopPrice": "9300",				// please ignore when order type is TRAILING_STOP_MARKET
+  		"closePosition": false,   // if Close-All
+  		"symbol": "BTCUSDT",
+  		"timeInForce": "GTC",
+  		"type": "TRAILING_STOP_MARKET",
+  		"activatePrice": "9020",			// activation price, only return with TRAILING_STOP_MARKET order
+  		"priceRate": "0.3",					// callback rate, only return with TRAILING_STOP_MARKET order
+	 	"updateTime": 1571110484038,
+	 	"workingType": "CONTRACT_PRICE",
+	 	"priceProtect": false            // if conditional order trigger is protected
+	},
+	{
+		"code": -2011,
+		"msg": "Unknown order sent."
+	}
+]
+```
+
+``DELETE /fapi/v3/guardedBatchOrders ``
+
+Cancel multiple active orders. Guarded variant of `DELETE /fapi/v3/batchOrders`, intended for orders placed/authorized on-chain: the on-chain nonce associated with each order is used to guard against duplicate or out-of-order cancellation. `signer`, `nonce`, and `signature` are required. Other request parameters and the response are identical to `DELETE /fapi/v3/batchOrders`.
+
+**Weight:**
+1
+
+**Parameters:**
+
+| Name                  | Type           | Mandatory | Description                                                                                     |
+| --------------------- | -------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| symbol                | STRING         | YES       |                                                                                                 |
+| orderIdList           | LIST\   | NO        | max length 10 e.g. [1234567,2345678]                                                      |
+| origClientOrderIdList | LIST\ | NO        | max length 10 e.g. ["my_id_1","my_id_2"], encode the double quotes. No space after comma. |
+| signer                | STRING         | YES       | API wallet address |
+| nonce                 | LONG           | YES       | The `nonce` that was used to place these orders (i.e. the `nonce` submitted with `POST /fapi/v3/batchOrders`), not a new/current timestamp |
+| signature             | STRING         | YES       | EIP-712 signature signed with the `signer` wallet private key |
+
+Either `orderIdList` or `origClientOrderIdList` must be sent.
 
 ## Auto-Cancel All Open Orders (TRADE)
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
@@ -73,8 +73,10 @@
 	- [批量下单 (TRADE)](#批量下单-trade)
 	- [查询订单 (USER_DATA)](#查询订单-user_data)
 	- [撤销订单 (TRADE)](#撤销订单-trade)
+	- [撤销订单(带保护) (TRADE)](#撤销订单带保护-trade)
 	- [撤销全部订单 (TRADE)](#撤销全部订单-trade)
 	- [批量撤销订单 (TRADE)](#批量撤销订单-trade)
+	- [批量撤销订单(带保护) (TRADE)](#批量撤销订单带保护-trade)
 	- [倒计时撤销所有订单 (TRADE)](#倒计时撤销所有订单-trade)
 	- [查询当前挂单 (USER_DATA)](#查询当前挂单-user_data)
 	- [查看当前全部挂单 (USER_DATA)](#查看当前全部挂单-user_data)
@@ -2835,6 +2837,59 @@ origClientOrderId | STRING | NO       | 用户自定义的订单号
 `orderId` 与 `origClientOrderId` 必须至少发送一个
 
 
+## 撤销订单(带保护) (TRADE)
+
+> **响应:**
+
+```javascript
+{
+ 	"clientOrderId": "myOrder1", // 用户自定义的订单号
+ 	"cumQty": "0",
+ 	"cumQuote": "0", // 成交金额
+ 	"executedQty": "0", // 成交量
+ 	"orderId": 283194212, // 系统订单号
+ 	"origQty": "11", // 原始委托数量
+ 	"price": "0", // 委托价格
+	"reduceOnly": false, // 仅减仓
+	"side": "BUY", // 买卖方向
+	"positionSide": "SHORT", // 持仓方向
+ 	"status": "CANCELED", // 订单状态
+ 	"stopPrice": "9300", // 触发价，对`TRAILING_STOP_MARKET`无效
+ 	"closePosition": false,   // 是否条件全平仓
+ 	"symbol": "BTCUSDT", // 交易对
+ 	"timeInForce": "GTC", // 有效方法
+ 	"origType": "TRAILING_STOP_MARKET",	// 触发前订单类型
+ 	"type": "TRAILING_STOP_MARKET", // 订单类型
+ 	"activatePrice": "9020", // 跟踪止损激活价格, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+  	"priceRate": "0.3",	// 跟踪止损回调比例, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+ 	"updateTime": 1571110484038, // 更新时间
+ 	"workingType": "CONTRACT_PRICE", // 条件价格触发类型
+ 	"priceProtect": false            // 是否开启条件单触发保护
+}
+```
+
+``
+DELETE /fapi/v3/guardedCancelOrder ``
+
+撤销一个有效订单。是 `DELETE /fapi/v3/order` 的带保护版本，适用于链上下单/授权的订单：使用订单关联的链上 nonce 防止重复或乱序撤单。`signer`、`nonce`、`signature` 为必填参数，其余请求参数与响应内容与 `DELETE /fapi/v3/order` 完全一致。
+
+**权重:**
+1
+
+**Parameters:**
+
+名称               |  类型   | 是否必需  |        描述
+----------------- | ------ | -------- | ------------------
+symbol            | STRING | YES      | 交易对
+orderId           | LONG   | NO       | 系统订单号
+origClientOrderId | STRING | NO       | 用户自定义的订单号
+signer            | STRING | YES      | API钱包地址
+nonce             | LONG   | YES      | 下单该订单时使用的 `nonce`（即 `POST /fapi/v3/order` 请求中提交的 `nonce`），而非新的/当前时间戳
+signature         | STRING | YES      | 使用 `signer` 钱包私钥签名的 EIP-712 签名
+
+`orderId` 与 `origClientOrderId` 必须至少发送一个
+
+
 ## 撤销全部订单 (TRADE)
 
 > **响应:**
@@ -2909,6 +2964,65 @@ DELETE /fapi/v3/batchOrders ``
 symbol                | STRING         | YES      | 交易对
 orderIdList           | LIST\<LONG\>   | NO       | 系统订单号, 最多支持10个订单 <br/> 比如`[1234567,2345678]`
 origClientOrderIdList | LIST\<STRING\> | NO       | 用户自定义的订单号, 最多支持10个订单 <br/> 比如`["my_id_1","my_id_2"]` 需要encode双引号。逗号后面没有空格。
+
+`orderIdList` 与 `origClientOrderIdList` 必须至少发送一个，不可同时发送
+
+
+## 批量撤销订单(带保护) (TRADE)
+
+> **响应:**
+
+```javascript
+[
+	{
+	 	"clientOrderId": "myOrder1", // 用户自定义的订单号
+	 	"cumQty": "0",
+	 	"cumQuote": "0", // 成交金额
+	 	"executedQty": "0", // 成交量
+	 	"orderId": 283194212, // 系统订单号
+	 	"origQty": "11", // 原始委托数量
+	 	"price": "0", // 委托价格
+		"reduceOnly": false, // 仅减仓
+		"side": "BUY", // 买卖方向
+		"positionSide": "SHORT", // 持仓方向
+	 	"status": "CANCELED", // 订单状态
+	 	"stopPrice": "9300", // 触发价，对`TRAILING_STOP_MARKET`无效
+	 	"closePosition": false,   // 是否条件全平仓
+	 	"symbol": "BTCUSDT", // 交易对
+	 	"timeInForce": "GTC", // 有效方法
+	 	"origType": "TRAILING_STOP_MARKET", // 触发前订单类型
+ 		"type": "TRAILING_STOP_MARKET", // 订单类型
+	 	"activatePrice": "9020", // 跟踪止损激活价格, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+  		"priceRate": "0.3",	// 跟踪止损回调比例, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+	 	"updateTime": 1571110484038, // 更新时间
+	 	"workingType": "CONTRACT_PRICE", // 条件价格触发类型
+	 	"priceProtect": false            // 是否开启条件单触发保护
+	},
+	{
+		"code": -2011,
+		"msg": "Unknown order sent."
+	}
+]
+```
+
+``
+DELETE /fapi/v3/guardedBatchOrders ``
+
+批量撤销有效订单。是 `DELETE /fapi/v3/batchOrders` 的带保护版本，适用于链上下单/授权的订单：使用每个订单关联的链上 nonce 防止重复或乱序撤单。`signer`、`nonce`、`signature` 为必填参数，其余请求参数与响应内容与 `DELETE /fapi/v3/batchOrders` 完全一致。
+
+**权重:**
+1
+
+**Parameters:**
+
+  名称          |      类型      | 是否必需 |       描述
+--------------------- | -------------- | -------- | ----------------
+symbol                | STRING         | YES      | 交易对
+orderIdList           | LIST\<LONG\>   | NO       | 系统订单号, 最多支持10个订单 <br/> 比如`[1234567,2345678]`
+origClientOrderIdList | LIST\<STRING\> | NO       | 用户自定义的订单号, 最多支持10个订单 <br/> 比如`["my_id_1","my_id_2"]` 需要encode双引号。逗号后面没有空格。
+signer                | STRING         | YES      | API钱包地址
+nonce                 | LONG           | YES      | 下单这些订单时使用的 `nonce`（即 `POST /fapi/v3/batchOrders` 请求中提交的 `nonce`），而非新的/当前时间戳
+signature             | STRING         | YES      | 使用 `signer` 钱包私钥签名的 EIP-712 签名
 
 `orderIdList` 与 `origClientOrderIdList` 必须至少发送一个，不可同时发送
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -77,8 +77,10 @@
 	- [批量下单 (TRADE)](#批量下单-trade)
 	- [查询订单 (USER_DATA)](#查询订单-user_data)
 	- [撤销订单 (TRADE)](#撤销订单-trade)
+	- [撤销订单(带保护) (TRADE)](#撤销订单带保护-trade)
 	- [撤销全部订单 (TRADE)](#撤销全部订单-trade)
 	- [批量撤销订单 (TRADE)](#批量撤销订单-trade)
+	- [批量撤销订单(带保护) (TRADE)](#批量撤销订单带保护-trade)
 	- [倒计时撤销所有订单 (TRADE)](#倒计时撤销所有订单-trade)
 	- [查询当前挂单 (USER_DATA)](#查询当前挂单-user_data)
 	- [查看当前全部挂单 (USER_DATA)](#查看当前全部挂单-user_data)
@@ -2928,6 +2930,59 @@ origClientOrderId | STRING | NO       | 用户自定义的订单号
 `orderId` 与 `origClientOrderId` 必须至少发送一个
 
 
+## 撤销订单(带保护) (TRADE)
+
+> **响应:**
+
+```javascript
+{
+ 	"clientOrderId": "myOrder1", // 用户自定义的订单号
+ 	"cumQty": "0",
+ 	"cumQuote": "0", // 成交金额
+ 	"executedQty": "0", // 成交量
+ 	"orderId": 283194212, // 系统订单号
+ 	"origQty": "11", // 原始委托数量
+ 	"price": "0", // 委托价格
+	"reduceOnly": false, // 仅减仓
+	"side": "BUY", // 买卖方向
+	"positionSide": "SHORT", // 持仓方向
+ 	"status": "CANCELED", // 订单状态
+ 	"stopPrice": "9300", // 触发价，对`TRAILING_STOP_MARKET`无效
+ 	"closePosition": false,   // 是否条件全平仓
+ 	"symbol": "BTCUSDT", // 交易对
+ 	"timeInForce": "GTC", // 有效方法
+ 	"origType": "TRAILING_STOP_MARKET",	// 触发前订单类型
+ 	"type": "TRAILING_STOP_MARKET", // 订单类型
+ 	"activatePrice": "9020", // 跟踪止损激活价格, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+  	"priceRate": "0.3",	// 跟踪止损回调比例, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+ 	"updateTime": 1571110484038, // 更新时间
+ 	"workingType": "CONTRACT_PRICE", // 条件价格触发类型
+ 	"priceProtect": false            // 是否开启条件单触发保护
+}
+```
+
+``
+DELETE /fapi/v3/guardedCancelOrder ``
+
+撤销一个有效订单。是 `DELETE /fapi/v3/order` 的带保护版本，适用于链上下单/授权的订单：使用订单关联的链上 nonce 防止重复或乱序撤单。`signer`、`nonce`、`signature` 为必填参数，其余请求参数与响应内容与 `DELETE /fapi/v3/order` 完全一致。
+
+**权重:**
+1
+
+**Parameters:**
+
+名称               |  类型   | 是否必需  |        描述
+----------------- | ------ | -------- | ------------------
+symbol            | STRING | YES      | 交易对
+orderId           | LONG   | NO       | 系统订单号
+origClientOrderId | STRING | NO       | 用户自定义的订单号
+signer            | STRING | YES      | API钱包地址
+nonce             | LONG   | YES      | 下单该订单时使用的 `nonce`（即 `POST /fapi/v3/order` 请求中提交的 `nonce`），而非新的/当前时间戳
+signature         | STRING | YES      | 使用 `signer` 钱包私钥签名的 EIP-712 签名
+
+`orderId` 与 `origClientOrderId` 必须至少发送一个
+
+
 ## 撤销全部订单 (TRADE)
 
 > **响应:**
@@ -3002,6 +3057,65 @@ DELETE /fapi/v3/batchOrders ``
 symbol                | STRING         | YES      | 交易对
 orderIdList           | LIST\<LONG\>   | NO       | 系统订单号, 最多支持10个订单 <br/> 比如`[1234567,2345678]`
 origClientOrderIdList | LIST\<STRING\> | NO       | 用户自定义的订单号, 最多支持10个订单 <br/> 比如`["my_id_1","my_id_2"]` 需要encode双引号。逗号后面没有空格。
+
+`orderIdList` 与 `origClientOrderIdList` 必须至少发送一个，不可同时发送
+
+
+## 批量撤销订单(带保护) (TRADE)
+
+> **响应:**
+
+```javascript
+[
+	{
+	 	"clientOrderId": "myOrder1", // 用户自定义的订单号
+	 	"cumQty": "0",
+	 	"cumQuote": "0", // 成交金额
+	 	"executedQty": "0", // 成交量
+	 	"orderId": 283194212, // 系统订单号
+	 	"origQty": "11", // 原始委托数量
+	 	"price": "0", // 委托价格
+		"reduceOnly": false, // 仅减仓
+		"side": "BUY", // 买卖方向
+		"positionSide": "SHORT", // 持仓方向
+	 	"status": "CANCELED", // 订单状态
+	 	"stopPrice": "9300", // 触发价，对`TRAILING_STOP_MARKET`无效
+	 	"closePosition": false,   // 是否条件全平仓
+	 	"symbol": "BTCUSDT", // 交易对
+	 	"timeInForce": "GTC", // 有效方法
+	 	"origType": "TRAILING_STOP_MARKET", // 触发前订单类型
+ 		"type": "TRAILING_STOP_MARKET", // 订单类型
+	 	"activatePrice": "9020", // 跟踪止损激活价格, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+  		"priceRate": "0.3",	// 跟踪止损回调比例, 仅`TRAILING_STOP_MARKET` 订单返回此字段
+	 	"updateTime": 1571110484038, // 更新时间
+	 	"workingType": "CONTRACT_PRICE", // 条件价格触发类型
+	 	"priceProtect": false            // 是否开启条件单触发保护
+	},
+	{
+		"code": -2011,
+		"msg": "Unknown order sent."
+	}
+]
+```
+
+``
+DELETE /fapi/v3/guardedBatchOrders ``
+
+批量撤销有效订单。是 `DELETE /fapi/v3/batchOrders` 的带保护版本，适用于链上下单/授权的订单：使用每个订单关联的链上 nonce 防止重复或乱序撤单。`signer`、`nonce`、`signature` 为必填参数，其余请求参数与响应内容与 `DELETE /fapi/v3/batchOrders` 完全一致。
+
+**权重:**
+1
+
+**Parameters:**
+
+  名称          |      类型      | 是否必需 |       描述
+--------------------- | -------------- | -------- | ----------------
+symbol                | STRING         | YES      | 交易对
+orderIdList           | LIST\<LONG\>   | NO       | 系统订单号, 最多支持10个订单 <br/> 比如`[1234567,2345678]`
+origClientOrderIdList | LIST\<STRING\> | NO       | 用户自定义的订单号, 最多支持10个订单 <br/> 比如`["my_id_1","my_id_2"]` 需要encode双引号。逗号后面没有空格。
+signer                | STRING         | YES      | API钱包地址
+nonce                 | LONG           | YES      | 下单这些订单时使用的 `nonce`（即 `POST /fapi/v3/batchOrders` 请求中提交的 `nonce`），而非新的/当前时间戳
+signature             | STRING         | YES      | 使用 `signer` 钱包私钥签名的 EIP-712 签名
 
 `orderIdList` 与 `origClientOrderIdList` 必须至少发送一个，不可同时发送
 


### PR DESCRIPTION
Add guarded cancel/batch-cancel endpoints for on-chain orders and document that their nonce must match the nonce originally used to place the order(s), not a fresh timestamp.