### PR TITLE
Add Deposit section and new withdraw params to aster-chain docs (EN & CN)

### DIFF
--- a/V3(Recommended)/EN/aster-chain.md
+++ b/V3(Recommended)/EN/aster-chain.md
@@ -18,6 +18,11 @@
   - [Update Lock Period (TRADE)](#update-lock-period-trade)
   - [Claim Rewards (TRADE)](#claim-rewards-trade)
   - [Get Locked Aster (NONE)](#get-locked-aster-none)
+- [Aster-Chain Deposit](#aster-chain-deposit)
+  - [EVM](#evm)
+  - [Solana](#solana)
+  - [SUI](#sui)
+  - [Get User Deposit Address (USER_DATA)](#get-user-deposit-address-user_data)
 - [Aster-Chain Perp Withdraw & Transfer Endpoints](#aster-chain-perp-withdraw--transfer-endpoints)
   - [User Withdraw (WITHDRAW)](#user-withdraw-withdraw)
   - [User Solana Withdraw (WITHDRAW)](#user-solana-withdraw-withdraw)
@@ -338,6 +343,110 @@ None
 
 ---
 
+# Aster-Chain Deposit
+
+Deposits are made on the source chain. The deposit method differs by network:
+
+## EVM
+
+Deposits on EVM chains are made by interacting directly with the vault contract on the source chain. There are two ways to deposit:
+
+1. Call the `depositFor` method of the vault contract. Once the transaction is confirmed on-chain, the deposited asset is credited to the `forAddress` account.
+2. Transfer the token directly to the vault contract address. The deposited asset is credited to the sending address.
+
+**Mainnet contract addresses:**
+
+| Chain | Chain ID | Contract Address |
+|-------|----------|------------------|
+| ETH | 1 | `0x604DD02d620633Ae427888d41bfd15e38483736E` |
+| BSC | 56 | `0x128463A60784c4D3f46c23Af3f65Ed859Ba87974` |
+| Arbitrum | 42161 | `0x9E36CB86a159d479cEd94Fa05036f235Ac40E1d5` |
+
+**depositFor:**
+
+```solidity
+function depositFor(address currency, address forAddress, uint256 amount, uint256 broker) external payable
+```
+
+| Name | Type | Description |
+|------|------|-------------|
+| currency | ADDRESS | Token contract address. For the native token, pass the fixed placeholder address `0xfdAE1bA7C826aBDc4c99903c8056f82a1A04a615` |
+| forAddress | ADDRESS | The user's address that receives the deposited asset |
+| amount | UINT256 | Deposit amount in the token's smallest unit (wei). For the native token, it must equal `msg.value` |
+| broker | UINT256 | Target account flag: pass `1000` to deposit to the **spot** account; any other value deposits to the **futures** account |
+
+* For ERC20 deposits, `approve` the vault contract to spend the token before calling `depositFor`, and `msg.value` must be `0`.
+* For native token deposits, send the amount via `msg.value`; it must equal the `amount` parameter.
+
+## Solana
+
+On Solana, deposits can **only** be made by calling the program methods below. Transferring SOL or tokens directly to the vault address will **not** be credited.
+
+**Mainnet program address:** `EhUtRgu9iEbZXXRpEvDj6n1wnQRjMi2SERDo3c6bmN2c`
+
+There are two deposit methods; both take a single argument `amount` (u64, in the token's smallest unit):
+
+1. `depositSol`: deposit the native token (SOL).
+2. `depositToken`: deposit an SPL token (e.g. USDT).
+
+**depositSol accounts:**
+
+| Account | isSigner | isMut | Description |
+|---------|----------|-------|-------------|
+| signer | true | true | The depositor's wallet address; the deposited asset is credited to this address |
+| admin | false | false | Admin account |
+| solVault | false | true | SOL vault account |
+| systemProgram | false | false | Fixed: `11111111111111111111111111111111` |
+
+**depositToken accounts:**
+
+| Account | isSigner | isMut | Description |
+|---------|----------|-------|-------------|
+| signer | true | false | The depositor's wallet address; the deposited asset is credited to this address |
+| admin | false | false | Admin account |
+| bank | false | false | Bank account of the token |
+| tokenVaultAuthority | false | false | Token vault authority |
+| tokenVault | false | true | Token vault account |
+| depositor | false | true | The depositor's associated token account of `tokenMint` |
+| tokenMint | false | false | Token mint address |
+| tokenProgram | false | false | Fixed: `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` |
+| associatedTokenProgram | false | false | Fixed: `ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL` |
+| systemProgram | false | false | Fixed: `11111111111111111111111111111111` |
+
+* Target account: for both methods, append the `programId` account (the program address) as the **last** account of the instruction to deposit to the **spot** account; omit it to deposit to the **futures** account.
+
+## SUI
+
+On SUI, only the **spot** account is supported. Deposits are made by transferring the asset directly to your dedicated deposit address — no contract call is required:
+
+1. Call [Get User Deposit Address (USER_DATA)](#get-user-deposit-address-user_data) to get your deposit address on SUI.
+2. Transfer the asset directly to that address; once the transaction is confirmed on-chain, it is credited to your spot account.
+
+## Get User Deposit Address (USER_DATA)
+
+> **Response:**
+
+```javascript
+{
+    "network": "SUI",
+    "address": "0x9a40f0119b670fb6b155744b51981f91c4c4c8a20c333441a63853fe7d055c90"
+}
+```
+
+`GET /aster-chain/v3/spot/user-deposit-address`
+
+Query the current user's dedicated deposit address on the specified network. Only the spot account is supported.
+
+**Weight:** 1
+
+**Parameters:**
+
+| Name | Type | Mandatory | Description |
+|------|------|-----------|-------------|
+| network | STRING | NO | Network type. Default: `"SUI"` |
+
+---
+
 # Aster-Chain Perp Withdraw & Transfer Endpoints
 
 ## User Withdraw (WITHDRAW)
@@ -367,7 +476,8 @@ Submit a withdrawal request from the perp account to an on-chain address.
 | fee | STRING | YES | Withdrawal fee |
 | receiver | STRING | YES | Recipient on-chain address |
 | userNonce | STRING | YES | User-side nonce included in the signature |
-| userSignature | STRING | YES | User signature over the withdrawal parameters |
+| signatureType | STRING | NO | Signature type: `"EOA"` or `"SafeWallet"`. Default: `"EOA"`. Pass `"SafeWallet"` if the account is a Safe wallet |
+| userSignature | STRING | YES | User signature over the withdrawal parameters. When `signatureType=SafeWallet`, multiple signatures are supported, separated by commas |
 
 ---
 
@@ -533,12 +643,14 @@ Submit a withdrawal request from the spot account to an on-chain address.
 | Name | Type | Mandatory | Description |
 |------|------|-----------|-------------|
 | asset | STRING | YES | Asset name (e.g. `"USDT"`) |
-| chainId | INTEGER | YES | Target chain ID |
+| chainId | INTEGER | YES | Chain ID of the chain the asset belongs to |
+| signatureChainId | INTEGER | NO | Chain ID of the chain used for signing (the `chainId` field of the EIP-712 domain). Defaults to `chainId` |
 | amount | STRING | YES | Withdrawal amount |
 | fee | STRING | YES | Withdrawal fee |
 | receiver | STRING | YES | Recipient on-chain address |
 | userNonce | STRING | YES | User-side nonce included in the signature |
-| userSignature | STRING | YES | User signature over the withdrawal parameters |
+| signatureType | STRING | NO | Signature type: `"EOA"` or `"SafeWallet"`. Default: `"EOA"`. Pass `"SafeWallet"` if the account is a Safe wallet |
+| userSignature | STRING | YES | User signature over the withdrawal parameters. When `signatureType=SafeWallet`, multiple signatures are supported, separated by commas |
 
 ---
 

--- a/V3(Recommended)/中文/aster-chain_CN.md
+++ b/V3(Recommended)/中文/aster-chain_CN.md
@@ -18,6 +18,11 @@
   - [更新锁定期 (TRADE)](#更新锁定期-trade)
   - [领取奖励 (TRADE)](#领取奖励-trade)
   - [查询锁定 Aster 总量 (NONE)](#查询锁定-aster-总量-none)
+- [Aster-Chain 充值](#aster-chain-充值)
+  - [EVM](#evm)
+  - [Solana](#solana)
+  - [SUI](#sui)
+  - [查询用户充值地址 (USER_DATA)](#查询用户充值地址-user_data)
 - [Aster-Chain 合约提现与划转接口](#aster-chain-合约提现与划转接口)
   - [合约提现 (WITHDRAW)](#合约提现-withdraw)
   - [合约 Solana 提现 (WITHDRAW)](#合约-solana-提现-withdraw)
@@ -338,6 +343,110 @@
 
 ---
 
+# Aster-Chain 充值
+
+充值在源链上完成，不同网络的充值方式不同：
+
+## EVM
+
+EVM 链的充值通过与源链上的 vault 合约直接交互完成，有两种方式：
+
+1. 调用 vault 合约的 `depositFor` 方法，交易链上确认后，资产入账至 `forAddress` 账户。
+2. 直接向 vault 合约地址转账，资产入账至转账发起地址。
+
+**主网合约地址：**
+
+| 链 | Chain ID | 合约地址 |
+|----|----------|----------|
+| ETH | 1 | `0x604DD02d620633Ae427888d41bfd15e38483736E` |
+| BSC | 56 | `0x128463A60784c4D3f46c23Af3f65Ed859Ba87974` |
+| Arbitrum | 42161 | `0x9E36CB86a159d479cEd94Fa05036f235Ac40E1d5` |
+
+**depositFor：**
+
+```solidity
+function depositFor(address currency, address forAddress, uint256 amount, uint256 broker) external payable
+```
+
+| 名称 | 类型 | 描述 |
+|------|------|------|
+| currency | ADDRESS | 代币合约地址；原生币（如 BNB、ETH）传固定占位地址 `0xfdAE1bA7C826aBDc4c99903c8056f82a1A04a615` |
+| forAddress | ADDRESS | 接收充值资产的用户地址 |
+| amount | UINT256 | 充值数量，使用代币最小单位（wei）；原生币必须与 `msg.value` 一致 |
+| broker | UINT256 | 目标账户标识：传 `1000` 充值至**现货**账户，其他值充值至**合约**账户 |
+
+* ERC20 充值需先对 vault 合约 `approve` 授权，且 `msg.value` 必须为 0。
+* 原生币充值通过 `msg.value` 转入，金额必须与 `amount` 参数一致。
+
+## Solana
+
+Solana 链上**只能**通过调用以下合约方法充值，直接向 vault 地址转账**不会**入账。
+
+**主网 Program 地址：** `EhUtRgu9iEbZXXRpEvDj6n1wnQRjMi2SERDo3c6bmN2c`
+
+共有两个充值方法，参数均为 `amount`（u64，代币最小单位）：
+
+1. `depositSol`：充值原生代币（SOL）。
+2. `depositToken`：充值 SPL 代币（如 USDT）。
+
+**depositSol accounts：**
+
+| 账户 | isSigner | isMut | 描述 |
+|------|----------|-------|------|
+| signer | true | true | 充值用户的钱包地址，资产入账至该地址 |
+| admin | false | false | Admin 账户 |
+| solVault | false | true | SOL vault 账户 |
+| systemProgram | false | false | 固定值：`11111111111111111111111111111111` |
+
+**depositToken accounts：**
+
+| 账户 | isSigner | isMut | 描述 |
+|------|----------|-------|------|
+| signer | true | false | 充值用户的钱包地址，资产入账至该地址 |
+| admin | false | false | Admin 账户 |
+| bank | false | false | 代币对应的 Bank 账户 |
+| tokenVaultAuthority | false | false | Token vault authority 账户 |
+| tokenVault | false | true | Token vault 账户 |
+| depositor | false | true | 充值用户在 `tokenMint` 下的关联代币账户（ATA） |
+| tokenMint | false | false | 代币 Mint 地址 |
+| tokenProgram | false | false | 固定值：`TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` |
+| associatedTokenProgram | false | false | 固定值：`ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL` |
+| systemProgram | false | false | 固定值：`11111111111111111111111111111111` |
+
+* 目标账户：调用任一方法时，在指令 accounts **最后**追加 `programId` 账户（即 Program 地址）表示充值至**现货**账户；不追加则充值至**合约**账户。
+
+## SUI
+
+SUI 链仅支持**现货**账户。充值通过直接向用户专属充值地址转账完成，无需调用合约：
+
+1. 调用[查询用户充值地址 (USER_DATA)](#查询用户充值地址-user_data) 获取 SUI 链上的充值地址。
+2. 直接向该地址转账，交易链上确认后，资产入账至现货账户。
+
+## 查询用户充值地址 (USER_DATA)
+
+> **响应:**
+
+```javascript
+{
+    "network": "SUI",
+    "address": "0x9a40f0119b670fb6b155744b51981f91c4c4c8a20c333441a63853fe7d055c90"
+}
+```
+
+`GET /aster-chain/v3/spot/user-deposit-address`
+
+查询当前用户在指定网络的专属充值地址。仅支持现货账户。
+
+**权重:** 1
+
+**参数:**
+
+| 名称 | 类型 | 是否必需 | 描述 |
+|------|------|---------|------|
+| network | STRING | NO | 网络类型，默认 `"SUI"` |
+
+---
+
 # Aster-Chain 合约提现与划转接口
 
 ## 合约提现 (WITHDRAW)
@@ -367,7 +476,8 @@
 | fee | STRING | YES | 提现手续费 |
 | receiver | STRING | YES | 接收方链上地址 |
 | userNonce | STRING | YES | 签名中包含的用户端 nonce |
-| userSignature | STRING | YES | 用户对提现参数的签名 |
+| signatureType | STRING | NO | 签名类型：`"EOA"` 或 `"SafeWallet"`，默认 `"EOA"`；账户为 Safe 钱包时传 `"SafeWallet"` |
+| userSignature | STRING | YES | 用户对提现参数的签名；当 `signatureType=SafeWallet` 时，支持多个签名，以逗号分隔 |
 
 ---
 
@@ -533,12 +643,14 @@
 | 名称 | 类型 | 是否必需 | 描述 |
 |------|------|---------|------|
 | asset | STRING | YES | 资产名称（如 `"USDT"`） |
-| chainId | INTEGER | YES | 目标链 ID |
+| chainId | INTEGER | YES | 资产所属链的 Chain ID |
+| signatureChainId | INTEGER | NO | 签名使用的链 ID（即 EIP-712 domain 中的 `chainId` 字段），未传时默认取 `chainId` |
 | amount | STRING | YES | 提现金额 |
 | fee | STRING | YES | 提现手续费 |
 | receiver | STRING | YES | 接收方链上地址 |
 | userNonce | STRING | YES | 签名中包含的用户端 nonce |
-| userSignature | STRING | YES | 用户对提现参数的签名 |
+| signatureType | STRING | NO | 签名类型：`"EOA"` 或 `"SafeWallet"`，默认 `"EOA"`；账户为 Safe 钱包时传 `"SafeWallet"` |
+| userSignature | STRING | YES | 用户对提现参数的签名；当 `signatureType=SafeWallet` 时，支持多个签名，以逗号分隔 |
 
 ---
 


### PR DESCRIPTION
 ## Summary

  - Add `signatureType` param (`EOA` / `SafeWallet`, default `EOA`) to perp and spot `user-withdraw`; when `SafeWallet`, `userSignature` accepts multiple comma-separated
  signatures
  - Add `signatureChainId` param to spot `user-withdraw` (the chain used for signing, defaults to `chainId`); clarify `chainId` as the chain the asset belongs to
  - Add a new top-level `Aster-Chain Deposit` section above the perp withdraw & transfer endpoints, covering EVM, Solana and SUI
  - EVM: deposit via `depositFor` contract call or direct transfer to the vault address; mainnet vault addresses (ETH / BSC / Arbitrum); `broker=1000` deposits to spot, other
  values to futures
  - Solana: deposits only via program calls (`depositSol` / `depositToken`) with accounts tables; appending `programId` as the last account deposits to spot, omitting it deposits
  to futures
  - SUI: spot account only; deposit by direct transfer to the user's dedicated deposit address
  - Document the new `GET /aster-chain/v3/spot/user-deposit-address` endpoint at the same heading level as EVM / Solana / SUI
  - Apply the same changes to both the English (`aster-chain.md`) and Chinese (`aster-chain_CN.md`) docs, and update both tables of contents
