### PR TITLE
Add -5050 DEPOSIT_REQUIRED error code and V3 auth deposit requirement…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 2026-08-31
+
+### Changed
+
+#### Spot V3 / Futures V3 authentication requirement: main wallet deposit required
+
+Starting **2026-09-01 00:00 UTC**, all authenticated V3 API endpoints will only be accessible once the main wallet linked to the Aster account has completed a deposit. This applies to endpoints requiring identity authentication, including account, order, trade, and other USER_DATA / TRADE endpoints.
+
+Not affected by this change:
+- Agent Wallet create / query / update / delete endpoints
+- Builder create / authorize / query / update / delete endpoints
+- Public market data endpoints requiring no authentication
+
+Until the main wallet has completed a deposit, affected authenticated V3 requests may fail with:
+```json
+{"code":-5050,"msg":"This function can only be used after deposit"}
+```
+
+Added the new `-5050 DEPOSIT_REQUIRED` error code to the Spot V3 and Futures V3 API references (EN and CN, mainnet and testnet).
+
+---
+
 ## 2026-07-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Official API documentation for Aster.
 
 - Use **V3 (Recommended)** for all new integrations
 - Starting from **March 25, 2026**, V1 new API Key creation is no longer supported. Existing API Keys will continue to work.
+- Starting from **September 1, 2026, 00:00 UTC**, all authenticated Spot V3 / Futures V3 endpoints (account, order, trade, and other USER_DATA / TRADE endpoints) are only accessible after the main wallet linked to the Aster account has completed a deposit. Agent Wallet and Builder endpoints, and public market data endpoints, are unaffected. Until the deposit is completed, affected requests return `{"code":-5050,"msg":"This function can only be used after deposit"}`. See [CHANGELOG](./CHANGELOG.md).
 - Choose **EN** / **中文** based on your preference
 
 ## 📖 Docs

--- a/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-testnet.md
@@ -123,6 +123,7 @@
   - [11xx - Request issues](#11xx---request-issues)
   - [20xx - Processing Issues](#20xx---processing-issues)
   - [40xx - Filters and other Issues](#40xx---filters-and-other-issues)
+  - [50xx - Deposit and Withdrawal Issues](#50xx---deposit-and-withdrawal-issues)
 
 # General Info
 
@@ -5322,4 +5323,10 @@ Codes are universal,but messages can vary.
 
 * Price is lower than stop price multiplier floor.
 * Limit price can't be lower than %s.
+
+## 50xx - Deposit and Withdrawal Issues
+
+> -5050 DEPOSIT_REQUIRED
+
+* This function can only be used after deposit.
 

--- a/V3(Recommended)/EN/aster-finance-futures-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-futures-api-v3.md
@@ -138,6 +138,7 @@
   - [11xx - Request issues](#11xx---request-issues)
   - [20xx - Processing Issues](#20xx---processing-issues)
   - [40xx - Filters and other Issues](#40xx---filters-and-other-issues)
+  - [50xx - Deposit and Withdrawal Issues](#50xx---deposit-and-withdrawal-issues)
 
 # General Info
 
@@ -6247,4 +6248,10 @@ Codes are universal,but messages can vary.
 
 * Price is lower than stop price multiplier floor.
 * Limit price can't be lower than %s.
+
+## 50xx - Deposit and Withdrawal Issues
+
+> -5050 DEPOSIT_REQUIRED
+
+* This function can only be used after deposit.
 

--- a/V3(Recommended)/EN/aster-finance-spot-api-testnet.md
+++ b/V3(Recommended)/EN/aster-finance-spot-api-testnet.md
@@ -2601,3 +2601,9 @@ Errors consist of two parts: an error code and a message. The code is standardiz
 * Take-Profit/Stop-Loss price must be above the trigger price × multiplier floor.  
 * Order price (limit or TP/SL) can’t be below %s.
 
+## 50xx \- Deposit and Withdrawal Issues
+
+### \-5050 DEPOSIT\_REQUIRED
+
+* This function can only be used after deposit.
+

--- a/V3(Recommended)/EN/aster-finance-spot-api-v3.md
+++ b/V3(Recommended)/EN/aster-finance-spot-api-v3.md
@@ -2642,3 +2642,9 @@ Errors consist of two parts: an error code and a message. The code is standardiz
 * Take-Profit/Stop-Loss price must be above the trigger price × multiplier floor.  
 * Order price (limit or TP/SL) can’t be below %s.
 
+## 50xx \- Deposit and Withdrawal Issues
+
+### \-5050 DEPOSIT\_REQUIRED
+
+* This function can only be used after deposit.
+

--- a/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-testnet_CN.md
@@ -118,6 +118,7 @@
 	- [11xx - Request issues](#11xx---request-issues)
 	- [20xx - Processing Issues](#20xx---processing-issues)
 	- [40xx - Filters and other Issues](#40xx---filters-and-other-issues)
+	- [50xx - Deposit and Withdrawal Issues](#50xx---deposit-and-withdrawal-issues)
 
 # 基本信息
 
@@ -5566,4 +5567,10 @@ None
  * 止盈止损订单价格不应低于触发价与报价乘数下限的乘积
  * Limit price can't be lower than %s.
  * 止盈止损订单价格不应低于 `%s`
+
+## 50xx - Deposit and Withdrawal Issues
+
+> -5050 DEPOSIT_REQUIRED
+ * This function can only be used after deposit.
+ * 该功能需要先完成充值后才能使用
 

--- a/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
+++ b/V3(Recommended)/中文/aster-finance-futures-api-v3_CN.md
@@ -136,6 +136,7 @@
 	- [11xx - Request issues](#11xx---request-issues)
 	- [20xx - Processing Issues](#20xx---processing-issues)
 	- [40xx - Filters and other Issues](#40xx---filters-and-other-issues)
+	- [50xx - Deposit and Withdrawal Issues](#50xx---deposit-and-withdrawal-issues)
 
 # 基本信息
 
@@ -6428,6 +6429,12 @@ None
  * 止盈止损订单价格不应低于触发价与报价乘数下限的乘积
  * Limit price can't be lower than %s.
  * 止盈止损订单价格不应低于 `%s`
+
+## 50xx - Deposit and Withdrawal Issues
+
+> -5050 DEPOSIT_REQUIRED
+ * This function can only be used after deposit.
+ * 该功能需要先完成充值后才能使用
 
 ---
 

--- a/V3(Recommended)/中文/aster-finance-spot-api-testnet_CN.md
+++ b/V3(Recommended)/中文/aster-finance-spot-api-testnet_CN.md
@@ -2682,4 +2682,10 @@ listenKey | STRING | YES
  * Price is lower than stop price multiplier floor.
  * 止盈止损订单价格不应低于触发价与报价乘数下限的乘积
  * Limit price can't be lower than %s.
- * 止盈止损订单价格不应低于 `%s`f
+ * 止盈止损订单价格不应低于 `%s`
+
+## 50xx - Deposit and Withdrawal Issues
+
+### -5050 DEPOSIT_REQUIRED
+ * This function can only be used after deposit.
+ * 该功能需要先完成充值后才能使用f

--- a/V3(Recommended)/中文/aster-finance-spot-api_CN-v3.md
+++ b/V3(Recommended)/中文/aster-finance-spot-api_CN-v3.md
@@ -2765,4 +2765,10 @@ listenKey | STRING | YES
  * Price is lower than stop price multiplier floor.
  * 止盈止损订单价格不应低于触发价与报价乘数下限的乘积
  * Limit price can't be lower than %s.
- * 止盈止损订单价格不应低于 `%s`f
+ * 止盈止损订单价格不应低于 `%s`
+
+## 50xx - Deposit and Withdrawal Issues
+
+### -5050 DEPOSIT_REQUIRED
+ * This function can only be used after deposit.
+ * 该功能需要先完成充值后才能使用f


### PR DESCRIPTION
… notice

Starting 2026-09-01 00:00 UTC, authenticated Spot V3 / Futures V3 endpoints require the account's main wallet to have completed a deposit. Documents the new -5050 error code across EN/CN, mainnet/testnet V3 references, and notes the change in README and CHANGELOG.